### PR TITLE
feat: Implement all-day events and refine date format

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,13 @@ To run the worker locally with mock data for testing:
 npm run dev
 ```
 
-This will start a local development server. You can access the ICS file at `http://localhost:8787/calendar.ics` (or the port indicated by Wrangler).
+This will start a local development server. You can access the ICS file at `http://localhost:8787/events.ics` (or the port indicated by Wrangler).
+
+To manually trigger the scheduled function locally (e.g., to force ICS regeneration):
+
+```bash
+curl "http://localhost:8787/cdn-cgi/handler/scheduled"
+```
 
 ## Deployment
 
@@ -96,19 +102,19 @@ To subscribe to this calendar, replace `your-worker-domain.workers.dev` with you
 
 1. Go to Settings > Calendar > Accounts > Add Account > Other
 2. Select "Add Subscribed Calendar"
-3. Enter the URL: `https://your-worker-domain.workers.dev/calendar.ics`
+3. Enter the URL: `https://your-worker-domain.workers.dev/events.ics`
 
 ### Google Calendar
 
 1. Open Google Calendar
 2. Click the + next to "Other calendars"
 3. Select "From URL"
-4. Enter the URL: `https://your-worker-domain.workers.dev/calendar.ics`
+4. Enter the URL: `https://your-worker-domain.workers.dev/events.ics`
 5. Click "Add Calendar"
 
 ### Microsoft Outlook
 
 1. Open Outlook Calendar
 2. Right-click on "Calendars" and select "Add Calendar" > "From Internet"
-3. Enter the URL: `https://your-worker-domain.workers.dev/calendar.ics`
+3. Enter the URL: `https://your-worker-domain.workers.dev/events.ics`
 4. Click "OK"

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,10 @@ export default {
           calendar.createEvent({
             start: event.start,
             end: event.start, // Event ends on the same day
-            summary: `${event.title} (~${event.end.getMonth() + 1}.${event.end.getDate().toString().padStart(2, '0')})`,
+            summary: `${event.title} (~${event.end.getMonth() + 1}. ${event.end
+              .getDate()
+              .toString()}.)`,
+            allDay: true,
           });
 
           // Create end event
@@ -78,12 +81,14 @@ export default {
             start: event.end,
             end: event.end, // Event ends on the same day
             summary: event.title,
+            allDay: true,
           });
         } else {
           calendar.createEvent({
             start: event.start,
             end: event.end,
             summary: event.title,
+            allDay: true,
           });
         }
       });


### PR DESCRIPTION
- Configure all generated calendar events as all-day events ().
- Preserve existing logic for splitting events longer than 3 days into separate start and end events, applying  to both.
- Refine date format in event summaries (e.g.,  to ) for improved readability.
- Update  with instructions for manually triggering the scheduled function locally.