### PR TITLE
refactor: remove heavy parser dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,6 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "axios": "^1.11.0",
-        "cheerio": "^1.1.0",
         "ical-generator": "^6.0.0"
       },
       "devDependencies": {
@@ -1679,35 +1677,12 @@
         "node": ">=12"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
-    "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/blake3-wasm": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
       "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/boolbase": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-      "license": "ISC"
     },
     "node_modules/cac": {
       "version": "6.7.14",
@@ -1717,19 +1692,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/chai": {
@@ -1757,48 +1719,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 16"
-      }
-    },
-    "node_modules/cheerio": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
-      "integrity": "sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg==",
-      "license": "MIT",
-      "dependencies": {
-        "cheerio-select": "^2.1.0",
-        "dom-serializer": "^2.0.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.2.2",
-        "encoding-sniffer": "^0.2.1",
-        "htmlparser2": "^10.0.0",
-        "parse5": "^7.3.0",
-        "parse5-htmlparser2-tree-adapter": "^7.1.0",
-        "parse5-parser-stream": "^7.1.2",
-        "undici": "^7.12.0",
-        "whatwg-mimetype": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=20.18.1"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
-      }
-    },
-    "node_modules/cheerio-select": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
-      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-select": "^5.1.0",
-        "css-what": "^6.1.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/color": {
@@ -1846,18 +1766,6 @@
         "simple-swizzle": "^0.2.2"
       }
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/cookie": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
@@ -1866,34 +1774,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/css-select": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
-      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-what": "^6.1.0",
-        "domhandler": "^5.0.2",
-        "domutils": "^3.0.1",
-        "nth-check": "^2.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/css-what": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
-      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">= 6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/cssstyle": {
@@ -1966,15 +1846,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/detect-libc": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
@@ -1983,100 +1854,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/dom-serializer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "entities": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/domelementtype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/domhandler": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/domutils": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
-      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "^2.0.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/encoding-sniffer": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
-      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
-      "license": "MIT",
-      "dependencies": {
-        "iconv-lite": "^0.6.3",
-        "whatwg-encoding": "^3.1.1"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
-      }
-    },
-    "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/error-stack-parser-es": {
@@ -2089,57 +1866,12 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/esbuild": {
       "version": "0.25.4",
@@ -2251,42 +1983,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2302,109 +1998,12 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true,
       "license": "BSD-2-Clause"
-    },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
@@ -2417,37 +2016,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/htmlparser2": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
-      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.2.1",
-        "entities": "^6.0.0"
-      }
-    },
-    "node_modules/htmlparser2/node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -2533,6 +2101,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -2636,15 +2205,6 @@
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/mime": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
@@ -2656,27 +2216,6 @@
       },
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/miniflare": {
@@ -2742,18 +2281,6 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/nth-check": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/nth-check?sponsor=1"
-      }
-    },
     "node_modules/nwsapi": {
       "version": "2.2.21",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.21.tgz",
@@ -2772,34 +2299,10 @@
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
       "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/parse5-htmlparser2-tree-adapter": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
-      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
-      "license": "MIT",
-      "dependencies": {
-        "domhandler": "^5.0.3",
-        "parse5": "^7.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/parse5-parser-stream": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
-      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
-      "license": "MIT",
-      "dependencies": {
-        "parse5": "^7.0.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
@@ -2809,6 +2312,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -2890,12 +2394,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2957,6 +2455,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/saxes": {
@@ -3261,6 +2760,7 @@
       "version": "7.12.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.12.0.tgz",
       "integrity": "sha512-GrKEsc3ughskmGA9jevVlIOPMiiAHJ4OFUtaAH+NhfTUSiZ1wMPIQqQvAJUrJspFXJt3EBWgpAeoHEDVT1IBug==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -3491,6 +2991,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
       "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "0.6.3"
@@ -3503,6 +3004,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
       "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -16,8 +16,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "axios": "^1.11.0",
-    "cheerio": "^1.1.0",
     "ical-generator": "^6.0.0"
   },
   "devDependencies": {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -92,7 +92,7 @@ export async function getEventsFromSite(currentYear: number): Promise<Event[]> {
       if (!title || title.includes("수업보강") || isHoliday(title)) continue;
 
       const startText = startMatch
-        ? startMatch[1].replace(/<[^>]*>/g, "").replace(/\s+/g, "").trim()
+        ? startMatch[1].replace(/[^0-9.-]/g, "").trim()
         : "";
       if (!startText) {
         log("warn", "Skipping event due to missing start date", { title });
@@ -100,7 +100,7 @@ export async function getEventsFromSite(currentYear: number): Promise<Event[]> {
       }
 
       let endText = endMatch
-        ? endMatch[1].replace(/<[^>]*>/g, "").replace(/\s+/g, "").replace("-", "").trim()
+        ? endMatch[1].replace(/[^0-9.-]/g, "").replace("-", "").trim()
         : "";
       if (!endText) endText = startText;
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,5 +1,3 @@
-import axios from "axios";
-import * as cheerio from "cheerio";
 import { log } from "./utils/logger";
 import { withRetry } from "./utils/retry";
 import { Event } from "./types";
@@ -12,13 +10,13 @@ import { HOLIDAYS, REQUEST_CONFIG } from "./constants";
  * @returns {string | null} ISO 형식의 날짜 문자열 ('YYYY-MM-DD') 또는 파싱 실패 시 null.
  */
 const parseDate = (dateText: string, currentYear: number): string | null => {
-  const dateParts = dateText.match(/\d{1,2}/g); // 최대 두 자리 숫자만 매칭
+  const dateParts = dateText.match(/\d{1,2}/g);
   if (!dateParts || dateParts.length < 2) {
     log("warn", "Could not parse date from text", { dateText });
     return null;
   }
   const [month, day] = dateParts.map((num) => num.padStart(2, "0"));
-  const year = Number(currentYear) + (Number(month) >= 3 ? 0 : 1); // 학사연도 기준 3월 이전이면 다음 해
+  const year = Number(currentYear) + (Number(month) >= 3 ? 0 : 1);
   return `${year}-${month}-${day}`;
 };
 
@@ -36,83 +34,81 @@ const isHoliday = (title: string): boolean =>
  * @returns {Promise<Event[]>} 학사 일정을 담은 객체 배열.
  */
 export async function getEventsFromSite(currentYear: number): Promise<Event[]> {
-  // Use mock data in development mode
-
   const url = `https://www.knue.ac.kr/www/selectSchdleWebList.do?key=542&searchY=${currentYear}&searchM=3`; // Start from March for academic year
 
   try {
     log("info", `Fetching events from ${url}`);
-    const { data } = await withRetry(
+    const html = await withRetry(
       () =>
-        axios.get(url, {
-          timeout: REQUEST_CONFIG.timeout,
+        fetch(url, {
           headers: {
             "User-Agent": REQUEST_CONFIG.userAgent,
           },
+        }).then((res) => {
+          if (!res.ok) {
+            throw new Error(`HTTP ${res.status}`);
+          }
+          return res.text();
         }),
       {
         maxRetries: REQUEST_CONFIG.maxRetries,
         delayMs: REQUEST_CONFIG.retryDelayMs,
       }
     );
-    const $ = cheerio.load(data);
-    const events: Event[] = [];
 
-    $("table.more_year tbody tr").each(function () {
-      let title = $(this).find(".more_link").text().trim();
+    const events: Event[] = [];
+    const tableMatch = html.match(/<table[^>]*class=["']more_year["'][^>]*>([\s\S]*?)<\/table>/);
+    if (!tableMatch) {
+      log("warn", "No events table found");
+      return events;
+    }
+
+    const rows = tableMatch[1].match(/<tr[^>]*>[\s\S]*?<\/tr>/g) || [];
+
+    for (const row of rows) {
+      const titleMatch = row.match(/<td[^>]*class=["']more_link["'][^>]*>([\s\S]*?)<\/td>/);
+      const startMatch = row.match(/<td[^>]*class=["']start["'][^>]*>([\s\S]*?)<\/td>/);
+      const endMatch = row.match(/<td[^>]*class=["']end["'][^>]*>([\s\S]*?)<\/td>/);
+
+      let title = titleMatch ? titleMatch[1].trim() : "";
 
       // Clean up title for ICS compatibility
-      // RFC 5545 specifies that commas, semicolons, and backslashes should be escaped in TEXT values
-      // However, some calendar apps have parsing issues with escaped characters
-      // Replacing commas with spaces provides better compatibility across different clients
-      title = title.replace(/[,]/g, " "); // Replace commas to avoid escaping issues
-      title = title.replace(/\s+/g, " "); // Normalize whitespace for cleaner display
-      title = title.replace(/학년도 /g, "-"); // Shorten academic year format for brevity
+      title = title.replace(/[,]/g, " ");
+      title = title.replace(/\s+/g, " ");
+      title = title.replace(/학년도 /g, "-");
       title = title.trim();
 
-      // Limit title length to prevent line wrapping issues in ICS format
-      // RFC 5545 allows line folding, but some calendar apps don't handle it well
-      // Keeping titles under 45 characters ensures better cross-platform compatibility
       if (title.length > 45) {
         title = title.substring(0, 42) + "...";
       }
 
-      if (title.includes("수업보강") || isHoliday(title)) return;
+      if (!title || title.includes("수업보강") || isHoliday(title)) continue;
 
-      const startText = $(this)
-        .find(".start")
-        .text()
-        .replace(/\s+/g, "")
-        .trim();
+      const startText = startMatch
+        ? startMatch[1].replace(/\s+/g, "").trim()
+        : "";
       if (!startText) {
         log("warn", "Skipping event due to missing start date", { title });
-        return;
+        continue;
       }
 
-      let endText = $(this)
-        .find(".end")
-        .text()
-        .replace(/\s+/g, "")
-        .replace("-", "")
-        .trim();
+      let endText = endMatch
+        ? endMatch[1].replace(/\s+/g, "").replace("-", "").trim()
+        : "";
       if (!endText) endText = startText;
 
       const startIso = parseDate(startText, currentYear);
-      if (!startIso) {
-        // 날짜 파싱 실패 시 해당 이벤트 건너뜀
-        return;
-      }
+      if (!startIso) continue;
 
       let endIso = parseDate(endText, currentYear);
-      if (!endIso) {
-        endIso = startIso; // 종료일이 없거나 파싱 실패 시 시작일과 동일하게 설정
-      }
+      if (!endIso) endIso = startIso;
 
       const startDate = new Date(startIso);
       const endDate = new Date(endIso);
 
       events.push({ start: startDate, end: endDate, title });
-    });
+    }
+
     log("info", `Successfully parsed ${events.length} events`);
     return events;
   } catch (error: unknown) {
@@ -124,3 +120,4 @@ export async function getEventsFromSite(currentYear: number): Promise<Event[]> {
     return [];
   }
 }
+

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -57,15 +57,22 @@ export async function getEventsFromSite(currentYear: number): Promise<Event[]> {
     );
 
     const events: Event[] = [];
-    const tableMatch = html.match(/<table[^>]*class=["']more_year["'][^>]*>([\s\S]*?)<\/table>/);
-    if (!tableMatch) {
+    const tableMatches = html.match(/<table[^>]*class=["']more_year["'][^>]*>([\s\S]*?)<\/table>/g);
+    if (!tableMatches || tableMatches.length === 0) {
       log("warn", "No events table found");
       return events;
     }
 
-    const rows = tableMatch[1].match(/<tr[^>]*>[\s\S]*?<\/tr>/g) || [];
+    const allRows: string[] = [];
+    for (const table of tableMatches) {
+      const tbodyMatch = table.match(/<tbody[^>]*>([\s\S]*?)<\/tbody>/);
+      if (tbodyMatch) {
+        const rows = tbodyMatch[1].match(/<tr[^>]*>[\s\S]*?<\/tr>/g) || [];
+        allRows.push(...rows);
+      }
+    }
 
-    for (const row of rows) {
+    for (const row of allRows) {
       const titleMatch = row.match(/<td[^>]*class=["']more_link["'][^>]*>([\s\S]*?)<\/td>/);
       const startMatch = row.match(/<td[^>]*class=["']start["'][^>]*>([\s\S]*?)<\/td>/);
       const endMatch = row.match(/<td[^>]*class=["']end["'][^>]*>([\s\S]*?)<\/td>/);
@@ -85,7 +92,7 @@ export async function getEventsFromSite(currentYear: number): Promise<Event[]> {
       if (!title || title.includes("수업보강") || isHoliday(title)) continue;
 
       const startText = startMatch
-        ? startMatch[1].replace(/\s+/g, "").trim()
+        ? startMatch[1].replace(/<[^>]*>/g, "").replace(/\s+/g, "").trim()
         : "";
       if (!startText) {
         log("warn", "Skipping event due to missing start date", { title });
@@ -93,7 +100,7 @@ export async function getEventsFromSite(currentYear: number): Promise<Event[]> {
       }
 
       let endText = endMatch
-        ? endMatch[1].replace(/\s+/g, "").replace("-", "").trim()
+        ? endMatch[1].replace(/<[^>]*>/g, "").replace(/\s+/g, "").replace("-", "").trim()
         : "";
       if (!endText) endText = startText;
 

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -1,22 +1,23 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import axios from 'axios';
 import { getEventsFromSite } from '../src/parser';
 import { mockHtmlResponse } from './helpers/mocks';
 
-vi.mock('axios');
-const mockedAxios = vi.mocked(axios);
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  fetchMock.mockReset();
+  // @ts-ignore
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe('Parser', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it('should parse events from HTML response', async () => {
-    mockedAxios.get.mockResolvedValue({ data: mockHtmlResponse });
+    fetchMock.mockResolvedValue(new Response(mockHtmlResponse));
 
     const events = await getEventsFromSite(2024);
 
@@ -42,8 +43,8 @@ describe('Parser', () => {
         </tbody>
       </table>
     `;
-    
-    mockedAxios.get.mockResolvedValue({ data: htmlWithHoliday });
+
+    fetchMock.mockResolvedValue(new Response(htmlWithHoliday));
 
     const events = await getEventsFromSite(2024);
 
@@ -68,8 +69,8 @@ describe('Parser', () => {
         </tbody>
       </table>
     `;
-    
-    mockedAxios.get.mockResolvedValue({ data: htmlWithMakeup });
+
+    fetchMock.mockResolvedValue(new Response(htmlWithMakeup));
 
     const events = await getEventsFromSite(2024);
 
@@ -78,7 +79,7 @@ describe('Parser', () => {
   });
 
   it('should handle events with end dates', async () => {
-    mockedAxios.get.mockResolvedValue({ data: mockHtmlResponse });
+    fetchMock.mockResolvedValue(new Response(mockHtmlResponse));
 
     const events = await getEventsFromSite(2024);
     const midtermEvent = events.find(e => e.title === '중간고사');
@@ -89,7 +90,7 @@ describe('Parser', () => {
   });
 
   it('should handle events without end dates', async () => {
-    mockedAxios.get.mockResolvedValue({ data: mockHtmlResponse });
+    fetchMock.mockResolvedValue(new Response(mockHtmlResponse));
 
     const events = await getEventsFromSite(2024);
     const startEvent = events.find(e => e.title === '개강일');
@@ -116,8 +117,8 @@ describe('Parser', () => {
         </tbody>
       </table>
     `;
-    
-    mockedAxios.get.mockResolvedValue({ data: htmlCrossYear });
+
+    fetchMock.mockResolvedValue(new Response(htmlCrossYear));
 
     const events = await getEventsFromSite(2024);
 
@@ -131,12 +132,12 @@ describe('Parser', () => {
   });
 
   it('should return empty array on network error', async () => {
-    mockedAxios.get.mockRejectedValue(new Error('Network error'));
+    fetchMock.mockRejectedValue(new Error('Network error'));
 
     const events = await getEventsFromSite(2024);
 
     expect(events).toEqual([]);
-    expect(mockedAxios.get).toHaveBeenCalledTimes(3); // Should retry 3 times
+    expect(fetchMock).toHaveBeenCalledTimes(3); // Should retry 3 times
   }, 10000); // 10 second timeout
 
   it('should skip events with missing start date', async () => {
@@ -156,8 +157,8 @@ describe('Parser', () => {
         </tbody>
       </table>
     `;
-    
-    mockedAxios.get.mockResolvedValue({ data: htmlMissingDate });
+
+    fetchMock.mockResolvedValue(new Response(htmlMissingDate));
 
     const events = await getEventsFromSite(2024);
 
@@ -167,8 +168,8 @@ describe('Parser', () => {
 
   it('should handle malformed HTML gracefully', async () => {
     const malformedHtml = '<div>Not a table</div>';
-    
-    mockedAxios.get.mockResolvedValue({ data: malformedHtml });
+
+    fetchMock.mockResolvedValue(new Response(malformedHtml));
 
     const events = await getEventsFromSite(2024);
 
@@ -177,14 +178,14 @@ describe('Parser', () => {
 
   it('should use retry mechanism on failure', async () => {
     // First two calls fail, third succeeds
-    mockedAxios.get
+    fetchMock
       .mockRejectedValueOnce(new Error('Network error'))
       .mockRejectedValueOnce(new Error('Timeout'))
-      .mockResolvedValue({ data: mockHtmlResponse });
+      .mockResolvedValue(new Response(mockHtmlResponse));
 
     const events = await getEventsFromSite(2024);
 
-    expect(mockedAxios.get).toHaveBeenCalledTimes(3);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
     expect(events).toHaveLength(2);
   }, 10000); // 10 second timeout
 });


### PR DESCRIPTION
## Summary
- replace axios/cheerio HTML parsing with native `fetch` and regex to cut CPU time on Workers
- drop unused axios/cheerio dependencies
- adjust parser tests to mock global `fetch`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68973f6e9864832e877978d0d83c6da3