### PR TITLE
[Behavioral](parser) Remove retry logic and fix KNUE website HTML parsing

### DIFF
--- a/.tasks/TASKS_CHEERIO_INTEGRATION.md
+++ b/.tasks/TASKS_CHEERIO_INTEGRATION.md
@@ -1,0 +1,233 @@
+# TASKS: Cheerio Integration for Robust HTML Parsing
+
+**Goal**: Replace regex-based HTML parsing with cheerio for better security, maintainability, and CodeQL compliance.
+
+**Motivation**:
+- CodeQL "Incomplete multi-character sanitization" warnings persist
+- Regex approach fragile for edge cases (badges, icons, extra markup)
+- cheerio provides safe, robust DOM parsing in Cloudflare Workers
+- Bundle size impact: ~100KB (acceptable for Workers 10MB limit)
+
+---
+
+## Phase 1: Setup & Dependency Management
+
+### Task 1.1: Install cheerio
+- [ ] Add cheerio to `package.json`
+  ```bash
+  npm install cheerio
+  ```
+- [ ] Verify bundle size impact with `npm ls cheerio`
+- [ ] Confirm Cloudflare Workers compatibility
+- [ ] Update `package-lock.json`
+
+**Acceptance Criteria**:
+- ✅ cheerio installed and available in imports
+- ✅ No breaking changes to existing dependencies
+- ✅ Build succeeds without warnings
+
+---
+
+## Phase 2: Parser Refactoring
+
+### Task 2.1: Refactor getEventsFromSite() with cheerio
+
+**Current Code** (regex-based):
+```typescript
+const tds = row.match(/<td[^>]*>([\s\S]*?)<\/td>/g) || [];
+const titleTd = tds[1];
+let title = titleTd
+  .replace(/<td[^>]*>/g, "")
+  .replace(/<\/td>/g, "")
+  .replace(/&nbsp;/g, " ")
+  .replace(/<[^>]*>/g, "")
+  .trim();
+```
+
+**Target Code** (cheerio-based):
+```typescript
+import * as cheerio from 'cheerio';
+
+const $ = cheerio.load(row);
+const tds = $('td');
+
+if (tds.length < 2) continue;
+
+// Extract date safely
+const dateRangeText = tds.eq(0).text().trim();
+
+// Extract title safely (removes all HTML)
+let title = tds.eq(1).text().trim();
+```
+
+**Implementation Steps**:
+1. Add cheerio import to `src/parser.ts`
+2. Refactor `getEventsFromSite()` function:
+   - Replace regex table/row matching with cheerio
+   - Use `$('table')` to find tables
+   - Use `$('tbody tr')` to iterate rows
+   - Use `.eq()` and `.text()` for safe text extraction
+3. Keep existing date/title cleaning logic
+4. Maintain same output: `Event[]` array
+
+**Acceptance Criteria**:
+- ✅ All text extraction uses cheerio selectors
+- ✅ No regex HTML tag removal (`/<[^>]*>/g`)
+- ✅ Code is more readable and maintainable
+- ✅ CodeQL warnings resolved
+
+---
+
+## Phase 3: Testing & Validation
+
+### Task 3.1: Update parser tests
+
+**Current Tests to Update**:
+- `should parse events from HTML response`
+- `should handle events with end dates`
+- `should extract title when extra markup exists`
+- All other parser tests
+
+**Changes Required**:
+- Mock HTML structure remains same (cheerio parses it identically)
+- Test assertions unchanged
+- No breaking changes to test expectations
+
+**New Test Cases** (if needed):
+- `should handle malformed HTML gracefully`
+- `should extract text from complex DOM structures`
+
+**Acceptance Criteria**:
+- ✅ All 63+ tests passing
+- ✅ Parser tests specifically verify cheerio behavior
+- ✅ No regressions from previous implementation
+
+### Task 3.2: Verify CodeQL warnings resolved
+
+- [ ] Run CodeQL locally or wait for GitHub scan
+- [ ] Confirm "Incomplete multi-character sanitization" warnings gone
+- [ ] Check for any new security warnings
+
+**Acceptance Criteria**:
+- ✅ CodeQL: 0 high/medium security issues
+- ✅ No "HTML injection" warnings
+- ✅ Clean security scan report
+
+### Task 3.3: Integration testing with real KNUE website
+
+- [ ] Test parser with actual KNUE website HTML
+- [ ] Verify events extracted correctly:
+  - Single date events: "03 . 01"
+  - Date range events: "03 . 04 - 03 . 10"
+  - Events with badges: `<a>제목</a><span>NEW</span>`
+  - Events with icons: `<a>제목</a><i></i>`
+- [ ] Compare with regex-based implementation
+
+**Acceptance Criteria**:
+- ✅ Same number of events extracted
+- ✅ Event titles match expected values
+- ✅ Date ranges parsed correctly
+- ✅ No silent failures or missed events
+
+---
+
+## Phase 4: Commit & PR Update
+
+### Task 4.1: Code review and cleanup
+
+- [ ] Code review for readability
+- [ ] Remove unnecessary comments
+- [ ] Verify TypeScript types are correct
+- [ ] Run linting: `npm run lint`
+- [ ] Run type checking: `npm run typecheck`
+
+### Task 4.2: Commit changes
+
+**Commit Message Format**:
+```
+[Refactor](parser) Replace regex with cheerio for robust HTML parsing
+
+- Add cheerio dependency (~100KB)
+- Refactor getEventsFromSite() to use cheerio selectors
+- Remove regex-based HTML tag stripping
+- Resolve CodeQL security warnings
+- Maintain 100% backward compatibility
+
+All 63+ tests passing
+CodeQL: 0 security warnings
+
+Generated with Claude Code
+```
+
+### Task 4.3: Update PR #18
+
+- [ ] Push to `fix/parser-retry-logic` branch
+- [ ] Update PR description with cheerio details
+- [ ] Comment on PR with summary of changes
+- [ ] Await GitHub checks (CodeQL, linting, tests)
+
+**Acceptance Criteria**:
+- ✅ All GitHub checks passing
+- ✅ CodeQL scan shows 0 issues
+- ✅ PR ready for review/merge
+
+---
+
+## File Changes Summary
+
+| File | Change | Impact |
+|------|--------|--------|
+| `package.json` | Add cheerio | +100KB bundle |
+| `src/parser.ts` | Refactor with cheerio | More maintainable |
+| `tests/parser.test.ts` | Update to match new logic | No behavior change |
+| PR #18 | Document changes | Clear context |
+
+---
+
+## Rollback Plan
+
+If issues arise:
+1. Revert to commit before cheerio install
+2. Keep regex-based approach with CodeQL exceptions
+3. Re-file issue for future security improvements
+
+---
+
+## Success Criteria
+
+✅ **All of the following must be true**:
+- [ ] cheerio successfully installed and available
+- [ ] Parser refactored to use cheerio selectors
+- [ ] 63+ tests passing
+- [ ] CodeQL warnings resolved (0 issues)
+- [ ] No regressions in event extraction
+- [ ] PR #18 updated and ready for merge
+- [ ] Bundle size acceptable (<10MB)
+- [ ] Cloudflare Workers deployment successful
+
+---
+
+## Timeline Estimate
+
+| Phase | Tasks | Est. Time |
+|-------|-------|-----------|
+| 1 | Setup & dependency | 5 min |
+| 2 | Parser refactoring | 30 min |
+| 3 | Testing & validation | 20 min |
+| 4 | Commit & PR update | 10 min |
+| **Total** | **All** | **~65 min** |
+
+---
+
+## Notes
+
+- Keep existing test structure (no major rewrites)
+- Maintain backward compatibility with existing Event interface
+- Document cheerio usage for future maintainers
+- Consider adding `.text()` method helper if needed for clarity
+
+---
+
+**Status**: 🔵 Ready to implement
+**Last Updated**: 2025-10-22
+**Owner**: kadragon + Claude Code

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "cheerio": "^1.1.2",
         "ical-generator": "^6.0.0"
       },
       "devDependencies": {
@@ -2510,6 +2511,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -2610,6 +2617,48 @@
         "node": ">= 16"
       }
     },
+    "node_modules/cheerio": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
+      "integrity": "sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.0.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.12.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/color": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
@@ -2685,6 +2734,34 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/cssstyle": {
@@ -2774,6 +2851,61 @@
         "node": ">=8"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -2787,6 +2919,31 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/error-stack-parser-es": {
       "version": "1.0.5",
@@ -3416,6 +3573,37 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/htmlparser2": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
+      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.1",
+        "entities": "^6.0.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -3515,7 +3703,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -4055,6 +4242,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/nwsapi": {
       "version": "2.2.21",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.21.tgz",
@@ -4143,10 +4342,34 @@
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
       "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
@@ -4156,7 +4379,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -4412,7 +4634,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/saxes": {
@@ -4938,7 +5159,6 @@
       "version": "7.12.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.12.0.tgz",
       "integrity": "sha512-GrKEsc3ughskmGA9jevVlIOPMiiAHJ4OFUtaAH+NhfTUSiZ1wMPIQqQvAJUrJspFXJt3EBWgpAeoHEDVT1IBug==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -5179,7 +5399,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
       "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "0.6.3"
@@ -5192,7 +5411,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
       "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "cheerio": "^1.1.2",
     "ical-generator": "^6.0.0"
   },
   "devDependencies": {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,6 +1,7 @@
 import { log } from "./utils/logger";
 import { Event } from "./types";
 import { HOLIDAYS, REQUEST_CONFIG } from "./constants";
+import * as cheerio from "cheerio";
 
 /**
  * 날짜 텍스트를 파싱하여 ISO 형식의 날짜 문자열로 변환합니다.
@@ -50,86 +51,75 @@ export async function getEventsFromSite(currentYear: number): Promise<Event[]> {
     const html = await res.text();
 
     const events: Event[] = [];
-    // Find all tables in the page (updated to handle tables without class attribute)
-    const tableMatches = html.match(/<table[^>]*>([\s\S]*?)<\/table>/g);
-    if (!tableMatches || tableMatches.length === 0) {
+    const $ = cheerio.load(html);
+
+    // Find all tables in the page
+    const tables = $("table");
+    if (tables.length === 0) {
       log("warn", "No events table found");
       return events;
     }
 
-    const allRows: string[] = [];
-    for (const table of tableMatches) {
-      const tbodyMatch = table.match(/<tbody[^>]*>([\s\S]*?)<\/tbody>/);
-      if (tbodyMatch) {
-        const rows = tbodyMatch[1].match(/<tr[^>]*>[\s\S]*?<\/tr>/g) || [];
-        allRows.push(...rows);
-      }
-    }
+    // Iterate through all tables and extract rows
+    tables.each((_tableIndex, tableElement) => {
+      const $table = $(tableElement);
+      const rows = $table.find("tbody tr");
 
-    for (const row of allRows) {
-      // Extract date range from first <td> (e.g., "02 . 28 - 03 . 01")
-      const tds = row.match(/<td[^>]*>([\s\S]*?)<\/td>/g) || [];
-      if (tds.length < 2) continue;
+      rows.each((_rowIndex, rowElement) => {
+        const $row = $(rowElement);
+        const $tds = $row.find("td");
 
-      // First column contains the date range
-      const dateRangeTd = tds[0];
-      if (!dateRangeTd) continue;
+        if ($tds.length < 2) return; // continue to next row
 
-      const dateRangeMatch = dateRangeTd.match(/<td[^>]*>([\s\S]*?)<\/td>/);
-      if (!dateRangeMatch) continue;
+        // Extract date range from first column (e.g., "02 . 28 - 03 . 01")
+        const dateRangeText = $tds.eq(0).text().trim();
+        if (!dateRangeText) {
+          return; // continue to next row
+        }
 
-      const dateRangeText = dateRangeMatch[1]
-        .replace(/&nbsp;/g, " ") // Convert HTML spaces
-        .replace(/<[^>]*>/g, "") // Remove HTML tags
-        .trim();
+        // Extract event title from second column (safely handles links, badges, icons, etc.)
+        let title = $tds.eq(1).text().trim();
 
-      // Second column contains the event title (may include links, badges, or other markup)
-      const titleTd = tds[1];
-      if (!titleTd) continue;
+        // Clean up title for ICS compatibility
+        title = title.replace(/[,]/g, " ")  // Replace commas with spaces
+                     .replace(/\s+/g, " ") // Collapse whitespace
+                     .trim();              // Remove leading/trailing whitespace
 
-      // Extract text content from <td>...</td>, handling any inner HTML structure
-      // This approach handles cases where badges, icons, or other elements follow the link
-      let title = titleTd
-        .replace(/<td[^>]*>/g, "")      // Remove opening <td> tag
-        .replace(/<\/td>/g, "")         // Remove closing </td> tag
-        .replace(/&nbsp;/g, " ")        // Convert HTML spaces
-        .replace(/<[^>]*>/g, "")        // Remove all HTML tags (links, spans, badges, etc.)
-        .replace(/[,]/g, " ")           // Replace commas with spaces
-        .replace(/\s+/g, " ")           // Collapse whitespace
-        .trim();                        // Remove leading/trailing whitespace
+        if (title.length > 45) {
+          title = title.substring(0, 42) + "...";
+        }
 
-      if (title.length > 45) {
-        title = title.substring(0, 42) + "...";
-      }
+        if (!title || title.includes("수업보강") || isHoliday(title)) {
+          return; // continue to next row
+        }
 
-      if (!title || title.includes("수업보강") || isHoliday(title)) continue;
+        // Parse date range (e.g., "02 . 28 - 03 . 01" or "03 . 01")
+        const dates = dateRangeText.split("-").map((d) => d.trim());
+        if (dates.length === 0) {
+          log("warn", "Skipping event due to missing date", { title });
+          return; // continue to next row
+        }
 
-      // Parse date range (e.g., "02 . 28 - 03 . 01" or "03 . 01")
-      const dates = dateRangeText.split("-").map((d) => d.trim());
-      if (dates.length === 0) {
-        log("warn", "Skipping event due to missing date", { title });
-        continue;
-      }
+        // Convert "02 . 28" format to "02.28"
+        const normalizeDate = (dateStr: string): string => {
+          return dateStr.replace(/\s+\.\s+/g, ".");
+        };
 
-      // Convert "02 . 28" format to "02.28"
-      const normalizeDate = (dateStr: string): string => {
-        return dateStr.replace(/\s+\.\s+/g, ".");
-      };
+        const startText = normalizeDate(dates[0]);
+        const endText = dates.length > 1 ? normalizeDate(dates[1]) : startText;
 
-      const startText = normalizeDate(dates[0]);
-      const endText = dates.length > 1 ? normalizeDate(dates[1]) : startText;
+        const startIso = parseDate(startText, currentYear);
+        if (!startIso) return; // continue to next row
 
-      const startIso = parseDate(startText, currentYear);
-      if (!startIso) continue;
+        let endIso = parseDate(endText, currentYear);
+        if (!endIso) endIso = startIso;
 
-      let endIso = parseDate(endText, currentYear);
-      if (!endIso) endIso = startIso;
+        const startDate = new Date(startIso);
+        const endDate = new Date(endIso);
 
-      const startDate = new Date(startIso);
-      const endDate = new Date(endIso);
-
-      events.push({ start: startDate, end: endDate, title });
-    }
+        events.push({ start: startDate, end: endDate, title });
+      });
+    });
 
     log("info", `Successfully parsed ${events.length} events`);
     return events;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -44,7 +44,7 @@ export async function getEventsFromSite(currentYear: number): Promise<Event[]> {
     });
 
     if (!res.ok) {
-      throw new Error(`HTTP ${res.status}`);
+      throw new Error(`HTTP ${res.status} - ${res.statusText}`);
     }
 
     const html = await res.text();
@@ -79,8 +79,8 @@ export async function getEventsFromSite(currentYear: number): Promise<Event[]> {
       if (!dateRangeMatch) continue;
 
       const dateRangeText = dateRangeMatch[1]
-        .replace(/<[^>]*>/g, "") // Remove HTML tags
         .replace(/&nbsp;/g, " ") // Convert HTML spaces
+        .replace(/<[^>]*>/g, "") // Remove HTML tags
         .trim();
 
       // Second column contains the event title (often within a link)
@@ -91,8 +91,8 @@ export async function getEventsFromSite(currentYear: number): Promise<Event[]> {
       let title = titleMatch ? titleMatch[1].trim() : "";
 
       // Clean up title for ICS compatibility
-      title = title.replace(/<[^>]*>/g, ""); // Remove any remaining HTML tags
       title = title.replace(/&nbsp;/g, " ");
+      title = title.replace(/<[^>]*>/g, ""); // Remove any remaining HTML tags
       title = title.replace(/[,]/g, " ");
       title = title.replace(/\s+/g, " ");
       title = title.trim();

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,5 +1,4 @@
 import { log } from "./utils/logger";
-import { withRetry } from "./utils/retry";
 import { Event } from "./types";
 import { HOLIDAYS, REQUEST_CONFIG } from "./constants";
 
@@ -38,26 +37,21 @@ export async function getEventsFromSite(currentYear: number): Promise<Event[]> {
 
   try {
     log("info", `Fetching events from ${url}`);
-    const html = await withRetry(
-      () =>
-        fetch(url, {
-          headers: {
-            "User-Agent": REQUEST_CONFIG.userAgent,
-          },
-        }).then((res) => {
-          if (!res.ok) {
-            throw new Error(`HTTP ${res.status}`);
-          }
-          return res.text();
-        }),
-      {
-        maxRetries: REQUEST_CONFIG.maxRetries,
-        delayMs: REQUEST_CONFIG.retryDelayMs,
-      }
-    );
+    const res = await fetch(url, {
+      headers: {
+        "User-Agent": REQUEST_CONFIG.userAgent,
+      },
+    });
+
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}`);
+    }
+
+    const html = await res.text();
 
     const events: Event[] = [];
-    const tableMatches = html.match(/<table[^>]*class=["']more_year["'][^>]*>([\s\S]*?)<\/table>/g);
+    // Find all tables in the page (updated to handle tables without class attribute)
+    const tableMatches = html.match(/<table[^>]*>([\s\S]*?)<\/table>/g);
     if (!tableMatches || tableMatches.length === 0) {
       log("warn", "No events table found");
       return events;
@@ -73,16 +67,34 @@ export async function getEventsFromSite(currentYear: number): Promise<Event[]> {
     }
 
     for (const row of allRows) {
-      const titleMatch = row.match(/<td[^>]*class=["']more_link["'][^>]*>([\s\S]*?)<\/td>/);
-      const startMatch = row.match(/<td[^>]*class=["']start["'][^>]*>([\s\S]*?)<\/td>/);
-      const endMatch = row.match(/<td[^>]*class=["']end["'][^>]*>([\s\S]*?)<\/td>/);
+      // Extract date range from first <td> (e.g., "02 . 28 - 03 . 01")
+      const tds = row.match(/<td[^>]*>([\s\S]*?)<\/td>/g) || [];
+      if (tds.length < 2) continue;
 
+      // First column contains the date range
+      const dateRangeTd = tds[0];
+      if (!dateRangeTd) continue;
+
+      const dateRangeMatch = dateRangeTd.match(/<td[^>]*>([\s\S]*?)<\/td>/);
+      if (!dateRangeMatch) continue;
+
+      const dateRangeText = dateRangeMatch[1]
+        .replace(/<[^>]*>/g, "") // Remove HTML tags
+        .replace(/&nbsp;/g, " ") // Convert HTML spaces
+        .trim();
+
+      // Second column contains the event title (often within a link)
+      const titleTd = tds[1];
+      if (!titleTd) continue;
+
+      const titleMatch = titleTd.match(/(?:<a[^>]*>)?([\s\S]*?)(?:<\/a>)?<\/td>/);
       let title = titleMatch ? titleMatch[1].trim() : "";
 
       // Clean up title for ICS compatibility
+      title = title.replace(/<[^>]*>/g, ""); // Remove any remaining HTML tags
+      title = title.replace(/&nbsp;/g, " ");
       title = title.replace(/[,]/g, " ");
       title = title.replace(/\s+/g, " ");
-      title = title.replace(/학년도 /g, "-");
       title = title.trim();
 
       if (title.length > 45) {
@@ -91,18 +103,20 @@ export async function getEventsFromSite(currentYear: number): Promise<Event[]> {
 
       if (!title || title.includes("수업보강") || isHoliday(title)) continue;
 
-      const startText = startMatch
-        ? startMatch[1].replace(/[^0-9.-]/g, "").trim()
-        : "";
-      if (!startText) {
-        log("warn", "Skipping event due to missing start date", { title });
+      // Parse date range (e.g., "02 . 28 - 03 . 01" or "03 . 01")
+      const dates = dateRangeText.split("-").map((d) => d.trim());
+      if (dates.length === 0) {
+        log("warn", "Skipping event due to missing date", { title });
         continue;
       }
 
-      let endText = endMatch
-        ? endMatch[1].replace(/[^0-9.-]/g, "").replace("-", "").trim()
-        : "";
-      if (!endText) endText = startText;
+      // Convert "02 . 28" format to "02.28"
+      const normalizeDate = (dateStr: string): string => {
+        return dateStr.replace(/\s+\.\s+/g, ".");
+      };
+
+      const startText = normalizeDate(dates[0]);
+      const endText = dates.length > 1 ? normalizeDate(dates[1]) : startText;
 
       const startIso = parseDate(startText, currentYear);
       if (!startIso) continue;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -83,19 +83,20 @@ export async function getEventsFromSite(currentYear: number): Promise<Event[]> {
         .replace(/<[^>]*>/g, "") // Remove HTML tags
         .trim();
 
-      // Second column contains the event title (often within a link)
+      // Second column contains the event title (may include links, badges, or other markup)
       const titleTd = tds[1];
       if (!titleTd) continue;
 
-      const titleMatch = titleTd.match(/(?:<a[^>]*>)?([\s\S]*?)(?:<\/a>)?<\/td>/);
-      let title = titleMatch ? titleMatch[1].trim() : "";
-
-      // Clean up title for ICS compatibility
-      title = title.replace(/&nbsp;/g, " ");
-      title = title.replace(/<[^>]*>/g, ""); // Remove any remaining HTML tags
-      title = title.replace(/[,]/g, " ");
-      title = title.replace(/\s+/g, " ");
-      title = title.trim();
+      // Extract text content from <td>...</td>, handling any inner HTML structure
+      // This approach handles cases where badges, icons, or other elements follow the link
+      let title = titleTd
+        .replace(/<td[^>]*>/g, "")      // Remove opening <td> tag
+        .replace(/<\/td>/g, "")         // Remove closing </td> tag
+        .replace(/&nbsp;/g, " ")        // Convert HTML spaces
+        .replace(/<[^>]*>/g, "")        // Remove all HTML tags (links, spans, badges, etc.)
+        .replace(/[,]/g, " ")           // Replace commas with spaces
+        .replace(/\s+/g, " ")           // Collapse whitespace
+        .trim();                        // Remove leading/trailing whitespace
 
       if (title.length > 45) {
         title = title.substring(0, 42) + "...";

--- a/tests/helpers/mocks.ts
+++ b/tests/helpers/mocks.ts
@@ -27,27 +27,29 @@ export const mockLongEvent: Event = {
 export const mockHtmlResponse = `
 <html>
 <body>
-  <table class="more_year">
+  <table>
+    <thead>
+      <tr>
+        <th>기간</th>
+        <th>일정</th>
+      </tr>
+    </thead>
     <tbody>
       <tr>
-        <td class="more_link">개강일</td>
-        <td class="start">3.1</td>
-        <td class="end"></td>
+        <td>03 . 01</td>
+        <td><a href="./selectSchdleWebView.do?key=542&schdleNum=976">개강일</a></td>
       </tr>
       <tr>
-        <td class="more_link">중간고사</td>
-        <td class="start">5.15</td>
-        <td class="end">5.17</td>
+        <td>05 . 15 - 05 . 17</td>
+        <td><a href="./selectSchdleWebView.do?key=542&schdleNum=977">중간고사</a></td>
       </tr>
       <tr>
-        <td class="more_link">수업보강</td>
-        <td class="start">4.1</td>
-        <td class="end"></td>
+        <td>04 . 01</td>
+        <td><a href="./selectSchdleWebView.do?key=542&schdleNum=978">수업보강</a></td>
       </tr>
       <tr>
-        <td class="more_link">어린이날</td>
-        <td class="start">5.5</td>
-        <td class="end"></td>
+        <td>05 . 05</td>
+        <td><a href="./selectSchdleWebView.do?key=542&schdleNum=979">어린이날</a></td>
       </tr>
     </tbody>
   </table>

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -27,17 +27,15 @@ describe('Parser', () => {
 
   it('should filter out holidays', async () => {
     const htmlWithHoliday = `
-      <table class="more_year">
+      <table>
         <tbody>
           <tr>
-            <td class="more_link">어린이날</td>
-            <td class="start">5.5</td>
-            <td class="end"></td>
+            <td>05 . 05</td>
+            <td><a href="#">어린이날</a></td>
           </tr>
           <tr>
-            <td class="more_link">정상 이벤트</td>
-            <td class="start">5.10</td>
-            <td class="end"></td>
+            <td>05 . 10</td>
+            <td><a href="#">정상 이벤트</a></td>
           </tr>
         </tbody>
       </table>
@@ -53,17 +51,15 @@ describe('Parser', () => {
 
   it('should filter out 수업보강 events', async () => {
     const htmlWithMakeup = `
-      <table class="more_year">
+      <table>
         <tbody>
           <tr>
-            <td class="more_link">수업보강</td>
-            <td class="start">4.1</td>
-            <td class="end"></td>
+            <td>04 . 01</td>
+            <td><a href="#">수업보강</a></td>
           </tr>
           <tr>
-            <td class="more_link">정상 이벤트</td>
-            <td class="start">4.2</td>
-            <td class="end"></td>
+            <td>04 . 02</td>
+            <td><a href="#">정상 이벤트</a></td>
           </tr>
         </tbody>
       </table>
@@ -101,17 +97,15 @@ describe('Parser', () => {
 
   it('should handle cross-year academic calendar', async () => {
     const htmlCrossYear = `
-      <table class="more_year">
+      <table>
         <tbody>
           <tr>
-            <td class="more_link">겨울방학</td>
-            <td class="start">1.15</td>
-            <td class="end">2.28</td>
+            <td>01 . 15 - 02 . 28</td>
+            <td><a href="#">겨울방학</a></td>
           </tr>
           <tr>
-            <td class="more_link">개강일</td>
-            <td class="start">3.1</td>
-            <td class="end"></td>
+            <td>03 . 01</td>
+            <td><a href="#">개강일</a></td>
           </tr>
         </tbody>
       </table>
@@ -136,22 +130,20 @@ describe('Parser', () => {
     const events = await getEventsFromSite(2024);
 
     expect(events).toEqual([]);
-    expect(fetchMock).toHaveBeenCalledTimes(3); // Should retry 3 times
-  }, 10000); // 10 second timeout
+    expect(fetchMock).toHaveBeenCalledTimes(1); // Should be called once, no retry
+  });
 
   it('should skip events with missing start date', async () => {
     const htmlMissingDate = `
-      <table class="more_year">
+      <table>
         <tbody>
           <tr>
-            <td class="more_link">이벤트 무효</td>
-            <td class="start"></td>
-            <td class="end"></td>
+            <td></td>
+            <td><a href="#">이벤트 무효</a></td>
           </tr>
           <tr>
-            <td class="more_link">정상 이벤트</td>
-            <td class="start">3.1</td>
-            <td class="end"></td>
+            <td>03 . 01</td>
+            <td><a href="#">정상 이벤트</a></td>
           </tr>
         </tbody>
       </table>
@@ -175,26 +167,13 @@ describe('Parser', () => {
     expect(events).toEqual([]);
   });
 
-  it('should use retry mechanism on failure', async () => {
-    // First two calls fail, third succeeds
-    fetchMock
-      .mockRejectedValueOnce(new Error('Network error'))
-      .mockRejectedValueOnce(new Error('Timeout'))
-      .mockResolvedValue(new Response(mockHtmlResponse));
-
-    const events = await getEventsFromSite(2024);
-
-    expect(fetchMock).toHaveBeenCalledTimes(3);
-    expect(events).toHaveLength(2);
-  }, 10000); // 10 second timeout
-
   it('should handle events with missing title gracefully', async () => {
     const htmlMissingTitle = `
-      <table class="more_year">
+      <table>
         <tbody>
           <tr>
-            <td class="start">3.1</td>
-            <td class="end"></td>
+            <td>03 . 01</td>
+            <td><a href="#"></a></td>
           </tr>
         </tbody>
       </table>
@@ -210,12 +189,11 @@ describe('Parser', () => {
   it('should truncate long titles', async () => {
     const longTitle = 'A'.repeat(50); // Longer than 45 chars
     const htmlLongTitle = `
-      <table class="more_year">
+      <table>
         <tbody>
           <tr>
-            <td class="more_link">${longTitle}</td>
-            <td class="start">3.1</td>
-            <td class="end"></td>
+            <td>03 . 01</td>
+            <td><a href="#">${longTitle}</a></td>
           </tr>
         </tbody>
       </table>
@@ -231,11 +209,11 @@ describe('Parser', () => {
 
   it('should handle events with missing start date gracefully', async () => {
     const htmlMissingStart = `
-      <table class="more_year">
+      <table>
         <tbody>
           <tr>
-            <td class="more_link">이벤트</td>
-            <td class="end">3.2</td>
+            <td></td>
+            <td><a href="#">이벤트</a></td>
           </tr>
         </tbody>
       </table>
@@ -250,11 +228,11 @@ describe('Parser', () => {
 
   it('should handle events with missing end date gracefully', async () => {
     const htmlMissingEnd = `
-      <table class="more_year">
+      <table>
         <tbody>
           <tr>
-            <td class="more_link">이벤트</td>
-            <td class="start">3.1</td>
+            <td>03 . 01</td>
+            <td><a href="#">이벤트</a></td>
           </tr>
         </tbody>
       </table>

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -255,4 +255,29 @@ describe('Parser', () => {
 
     expect(events).toEqual([]);
   });
+
+  it('should extract title when extra markup (badges, icons) exists', async () => {
+    const htmlWithBadge = `
+      <table>
+        <tbody>
+          <tr>
+            <td>03 . 01</td>
+            <td><a href="#">중간고사</a><span class="tag-new"></span></td>
+          </tr>
+          <tr>
+            <td>03 . 02</td>
+            <td><a href="#">개강일</a><i class="icon-important"></i><em></em></td>
+          </tr>
+        </tbody>
+      </table>
+    `;
+
+    fetchMock.mockResolvedValue(new Response(htmlWithBadge));
+
+    const events = await getEventsFromSite(2024);
+
+    expect(events).toHaveLength(2);
+    expect(events[0].title).toBe('중간고사');
+    expect(events[1].title).toBe('개강일');
+  });
 });


### PR DESCRIPTION
Updates:
- Removed withRetry mechanism - fetch now fails immediately on error
- Updated parser to handle new KNUE website table structure
- Tables no longer have class="more_year" attribute
- Date format changed from "MM.DD" to "MM . DD" (with spaces)
- Event titles moved from class="more_link" td to links within second column
- Removed retry-related tests ("should use retry mechanism on failure")
- Updated "should return empty array on network error" test to expect 1 call instead of 3

All 62 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>