### PR TITLE
Align Vitest dependencies and lockfile

### DIFF
--- a/.tasks/2025-11-22-npm-ci-vitest-lock/PLAN.md
+++ b/.tasks/2025-11-22-npm-ci-vitest-lock/PLAN.md
@@ -1,0 +1,23 @@
+# PLAN — 2025-11-22-npm-ci-vitest-lock
+
+- **Plan Date**: 2025-11-22T12:04:25+09:00
+- **Owner**: Codex
+
+## Objectives
+- Align Vitest-related dependencies and lockfile to satisfy SPEC-INFRA-CF-001 acceptance for clean Wrangler builds.
+
+## Work Items
+1. Bump `vitest`, `@vitest/ui`, and `@vitest/coverage-v8` devDependencies to `^4.0.13` to match resolved versions — Tests: `npm test` — Rollback: revert package.json and package-lock.json.
+2. Regenerate `package-lock.json` via `npm install` to sync versions — Tests: `npm ci` dry-run locally — Rollback: restore previous lockfile.
+3. Verify test suite with `npm test` to ensure tooling works after dependency update — Rollback: restore previous dependency versions if failures arise.
+
+## Risk Assessment
+- Risk: Potential Vitest minor patch behavior change — Mitigation: run full test suite to confirm.
+
+## Dependencies
+- npm registry availability; local Node 22.16.0 per environment.
+
+## Approval Checklist
+- [ ] Maintainer review
+- [x] Spec alignment confirmed
+- [ ] Tests identified

--- a/.tasks/2025-11-22-npm-ci-vitest-lock/PLAN.md
+++ b/.tasks/2025-11-22-npm-ci-vitest-lock/PLAN.md
@@ -15,7 +15,7 @@
 - Risk: Potential Vitest minor patch behavior change — Mitigation: run full test suite to confirm.
 
 ## Dependencies
-- npm registry availability; local Node 22.16.0 per environment.
+- npm registry availability; runtime >= Node 20 per package.json (`engines`), executed with Node 22.16.0 locally to mirror build env.
 
 ## Approval Checklist
 - [ ] Maintainer review

--- a/.tasks/2025-11-22-npm-ci-vitest-lock/PLAN.md
+++ b/.tasks/2025-11-22-npm-ci-vitest-lock/PLAN.md
@@ -20,4 +20,4 @@
 ## Approval Checklist
 - [ ] Maintainer review
 - [x] Spec alignment confirmed
-- [ ] Tests identified
+- [x] Tests identified

--- a/.tasks/2025-11-22-npm-ci-vitest-lock/PROGRESS.md
+++ b/.tasks/2025-11-22-npm-ci-vitest-lock/PROGRESS.md
@@ -9,6 +9,7 @@
 | 2025-11-22T12:06:07+09:00 | Implement | Verified clean install works. | npm ci (pass) |
 | 2025-11-22T12:20:00+09:00 | Review | Clarified Node version note in PLAN to state engines >=20, executed on Node 22.16.0. | n/a |
 | 2025-11-22T12:22:30+09:00 | Review | Marked approval checklist 'Tests identified' as completed per reviewer note. | n/a |
+| 2025-11-22T12:25:10+09:00 | Implement | Pinned Vitest devDependencies to exact 4.0.13 to improve reproducibility. | npm test (pass) |
 
 ## Decisions
 - Proceed with aligning Vitest dependencies to 4.0.13 and regenerating lockfile.

--- a/.tasks/2025-11-22-npm-ci-vitest-lock/PROGRESS.md
+++ b/.tasks/2025-11-22-npm-ci-vitest-lock/PROGRESS.md
@@ -8,6 +8,7 @@
 | 2025-11-22T12:05:52+09:00 | Implement | Ran test suite after dependency update. | npm test (pass) |
 | 2025-11-22T12:06:07+09:00 | Implement | Verified clean install works. | npm ci (pass) |
 | 2025-11-22T12:20:00+09:00 | Review | Clarified Node version note in PLAN to state engines >=20, executed on Node 22.16.0. | n/a |
+| 2025-11-22T12:22:30+09:00 | Review | Marked approval checklist 'Tests identified' as completed per reviewer note. | n/a |
 
 ## Decisions
 - Proceed with aligning Vitest dependencies to 4.0.13 and regenerating lockfile.

--- a/.tasks/2025-11-22-npm-ci-vitest-lock/PROGRESS.md
+++ b/.tasks/2025-11-22-npm-ci-vitest-lock/PROGRESS.md
@@ -7,6 +7,7 @@
 | 2025-11-22T12:05:30+09:00 | Implement | Updated package.json vitest deps to ^4.0.13; regenerated package-lock via npm install. | n/a |
 | 2025-11-22T12:05:52+09:00 | Implement | Ran test suite after dependency update. | npm test (pass) |
 | 2025-11-22T12:06:07+09:00 | Implement | Verified clean install works. | npm ci (pass) |
+| 2025-11-22T12:20:00+09:00 | Review | Clarified Node version note in PLAN to state engines >=20, executed on Node 22.16.0. | n/a |
 
 ## Decisions
 - Proceed with aligning Vitest dependencies to 4.0.13 and regenerating lockfile.

--- a/.tasks/2025-11-22-npm-ci-vitest-lock/PROGRESS.md
+++ b/.tasks/2025-11-22-npm-ci-vitest-lock/PROGRESS.md
@@ -1,0 +1,15 @@
+# PROGRESS — 2025-11-22-npm-ci-vitest-lock
+
+| Timestamp (ISO-8601) | Phase | Notes | Tests |
+| -------------------- | ----- | ----- | ----- |
+| 2025-11-22T12:04:25+09:00 | Research | Logged npm ci Vitest version mismatch; linked SPEC-INFRA-CF-001. | n/a |
+| 2025-11-22T12:04:25+09:00 | Plan | Chose to align Vitest dependencies to 4.0.13 and regenerate lockfile. | n/a |
+| 2025-11-22T12:05:30+09:00 | Implement | Updated package.json vitest deps to ^4.0.13; regenerated package-lock via npm install. | n/a |
+| 2025-11-22T12:05:52+09:00 | Implement | Ran test suite after dependency update. | npm test (pass) |
+| 2025-11-22T12:06:07+09:00 | Implement | Verified clean install works. | npm ci (pass) |
+
+## Decisions
+- Proceed with aligning Vitest dependencies to 4.0.13 and regenerating lockfile.
+
+## Blockers
+- None.

--- a/.tasks/2025-11-22-npm-ci-vitest-lock/RESEARCH.md
+++ b/.tasks/2025-11-22-npm-ci-vitest-lock/RESEARCH.md
@@ -1,0 +1,26 @@
+# RESEARCH — 2025-11-22-npm-ci-vitest-lock
+
+- **Date Opened**: 2025-11-22T12:04:25+09:00
+- **Owner**: Codex
+- **Related Specs**: SPEC-INFRA-CF-001
+
+## Goals
+- Understand why `npm ci` fails during Wrangler build.
+- Identify dependency/lockfile mismatch preventing installation.
+
+## Findings
+- Build log reports `npm ci` failure: lock file's `vitest@4.0.13` does not satisfy `vitest@4.0.10`, indicating package-lock and package.json are out of sync for Vitest packages.
+- package.json devDependencies pin Vitest packages with range `^4.0.10`, while package-lock includes mixed versions (root Vitest 4.0.13, some @vitest/* at 4.0.10/4.0.13), leading npm 10 to deem the lockfile invalid for clean install.
+
+## Evidence Log
+- [x] Source: provided Wrangler build log — shows `npm ci` EUSAGE and Vitest version mismatch errors.
+- [x] Source: package.json — devDependencies `vitest`, `@vitest/ui`, `@vitest/coverage-v8` set to `^4.0.10`.
+- [x] Source: package-lock.json — `node_modules/vitest` at `4.0.13` while some @vitest/* entries remain at `4.0.10`.
+
+## Open Questions
+- None; resolution path is to resync package.json and package-lock for Vitest suite.
+
+## Next Actions
+- Update Vitest-related devDependencies to the latest compatible patch (4.0.13) for consistency.
+- Regenerate package-lock.json to reflect aligned versions.
+- Run `npm test` to verify the toolchain after the update.

--- a/.tasks/2025-11-22-npm-ci-vitest-lock/SPEC-DELTA.md
+++ b/.tasks/2025-11-22-npm-ci-vitest-lock/SPEC-DELTA.md
@@ -1,0 +1,21 @@
+# SPEC-DELTA — 2025-11-22-npm-ci-vitest-lock
+
+- **Revision Date**: 2025-11-22T12:04:25+09:00
+- **Owner**: Codex
+
+## Summary
+- No functional spec changes; dependency alignment to satisfy SPEC-INFRA-CF-001 build acceptance.
+
+## Acceptance Criteria Updates
+- SPEC ID: SPEC-INFRA-CF-001 — Clarify that dependency lockfile must be consistent to allow `npm run build` / `npm ci` to complete without errors.
+
+## Impacted Modules
+- package.json
+- package-lock.json
+
+## Verification Plan
+- Tests: `npm test` (vitest) must pass after dependency update.
+- Build: `npm ci` should complete locally without errors.
+
+## Approvals
+- Maintainer: pending

--- a/.tasks/2025-11-22-npm-ci-vitest-lock/TASK_SUMMARY.md
+++ b/.tasks/2025-11-22-npm-ci-vitest-lock/TASK_SUMMARY.md
@@ -1,0 +1,26 @@
+# TASK SUMMARY — 2025-11-22-npm-ci-vitest-lock
+
+- **Completion Date**: 2025-11-22T12:06:07+09:00
+- **Owner**: Codex
+- **Status**: Completed
+
+## Outcome
+- Updated Vitest-related devDependencies to ^4.0.13 and regenerated package-lock, eliminating npm ci lockfile mismatch.
+- Confirmed `npm test` and `npm ci` now complete successfully, satisfying SPEC-INFRA-CF-001 build requirement.
+
+## Deliverables
+- Code: package.json, package-lock.json updates.
+- Specs: SPEC-INFRA-CF-001 (clarified via SPEC-DELTA note, no functional changes).
+- Tests: `npm test` (pass).
+
+## Metrics
+- Coverage: unchanged (not measured in this task).
+- Latency: N/A
+
+## Follow-up Actions
+- None.
+
+## Archive Checklist
+- [ ] Folder moved to `.tasks/_archive/YYYY/Q/2025-11-22-npm-ci-vitest-lock/`
+- [ ] `TASKS_ARCHIVE_INDEX.md` updated
+- [ ] Stakeholders notified

--- a/.tasks/TASKS.md
+++ b/.tasks/TASKS.md
@@ -19,6 +19,7 @@
 - Add test to pre-commit hook
 - Measure test coverage
 - Improve Test Coverage
+- Resolve npm ci Vitest lockfile mismatch (2025-11-22-npm-ci-vitest-lock)
 
 ## Archived Tasks
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,15 +17,15 @@
         "@types/node": "^24.1.0",
         "@typescript-eslint/eslint-plugin": "^8.46.1",
         "@typescript-eslint/parser": "^8.46.1",
-        "@vitest/coverage-v8": "^4.0.13",
+        "@vitest/coverage-v8": "4.0.13",
         "@vitest/eslint-plugin": "^1.4.0",
-        "@vitest/ui": "^4.0.13",
+        "@vitest/ui": "4.0.13",
         "eslint": "^9.39.0",
         "eslint-config-prettier": "^10.1.8",
         "husky": "^9.1.7",
         "jsdom": "^27.1.0",
         "typescript": "^5.9.3",
-        "vitest": "^4.0.13",
+        "vitest": "4.0.13",
         "wrangler": "^4.25.0"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,16 +17,19 @@
         "@types/node": "^24.1.0",
         "@typescript-eslint/eslint-plugin": "^8.46.1",
         "@typescript-eslint/parser": "^8.46.1",
-        "@vitest/coverage-v8": "^4.0.10",
+        "@vitest/coverage-v8": "^4.0.13",
         "@vitest/eslint-plugin": "^1.4.0",
-        "@vitest/ui": "^4.0.10",
+        "@vitest/ui": "^4.0.13",
         "eslint": "^9.39.0",
         "eslint-config-prettier": "^10.1.8",
         "husky": "^9.1.7",
         "jsdom": "^27.1.0",
         "typescript": "^5.9.3",
-        "vitest": "^4.0.10",
+        "vitest": "^4.0.13",
         "wrangler": "^4.25.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@acemir/cssom": {
@@ -2197,14 +2200,14 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.10.tgz",
-      "integrity": "sha512-g+brmtoKa/sAeIohNJnnWhnHtU6GuqqVOSQ4SxDIPcgZWZyhJs5RmF5LpqXs8Kq64lANP+vnbn5JLzhLj/G56g==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.13.tgz",
+      "integrity": "sha512-w77N6bmtJ3CFnL/YHiYotwW/JI3oDlR3K38WEIqegRfdMSScaYxwYKB/0jSNpOTZzUjQkG8HHEz4sdWQMWpQ5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.0.10",
+        "@vitest/utils": "4.0.13",
         "ast-v8-to-istanbul": "^0.3.8",
         "debug": "^4.4.3",
         "istanbul-lib-coverage": "^3.2.2",
@@ -2219,40 +2222,13 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.0.10",
-        "vitest": "4.0.10"
+        "@vitest/browser": "4.0.13",
+        "vitest": "4.0.13"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@vitest/coverage-v8/node_modules/@vitest/pretty-format": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.10.tgz",
-      "integrity": "sha512-99EQbpa/zuDnvVjthwz5bH9o8iPefoQZ63WV8+bsRJZNw3qQSvSltfut8yu1Jc9mqOYi7pEbsKxYTi/rjaq6PA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^3.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/coverage-v8/node_modules/@vitest/utils": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.10.tgz",
-      "integrity": "sha512-kOuqWnEwZNtQxMKg3WmPK1vmhZu9WcoX69iwWjVz+jvKTsF1emzsv3eoPcDr6ykA3qP2bsCQE7CwqfNtAVzsmg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.0.10",
-        "tinyrainbow": "^3.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -27,15 +27,15 @@
     "@types/node": "^24.1.0",
     "@typescript-eslint/eslint-plugin": "^8.46.1",
     "@typescript-eslint/parser": "^8.46.1",
-    "@vitest/coverage-v8": "^4.0.13",
+    "@vitest/coverage-v8": "4.0.13",
     "@vitest/eslint-plugin": "^1.4.0",
-    "@vitest/ui": "^4.0.13",
+    "@vitest/ui": "4.0.13",
     "eslint": "^9.39.0",
     "eslint-config-prettier": "^10.1.8",
     "husky": "^9.1.7",
     "jsdom": "^27.1.0",
     "typescript": "^5.9.3",
-    "vitest": "^4.0.13",
+    "vitest": "4.0.13",
     "wrangler": "^4.25.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,15 +27,15 @@
     "@types/node": "^24.1.0",
     "@typescript-eslint/eslint-plugin": "^8.46.1",
     "@typescript-eslint/parser": "^8.46.1",
-    "@vitest/coverage-v8": "^4.0.10",
+    "@vitest/coverage-v8": "^4.0.13",
     "@vitest/eslint-plugin": "^1.4.0",
-    "@vitest/ui": "^4.0.10",
+    "@vitest/ui": "^4.0.13",
     "eslint": "^9.39.0",
     "eslint-config-prettier": "^10.1.8",
     "husky": "^9.1.7",
     "jsdom": "^27.1.0",
     "typescript": "^5.9.3",
-    "vitest": "^4.0.10",
+    "vitest": "^4.0.13",
     "wrangler": "^4.25.0"
   }
 }


### PR DESCRIPTION
Update Vitest-related dependencies to version 4.0.13 and regenerate the package-lock.json to resolve version mismatches, ensuring compatibility with the build process as per SPEC-INFRA-CF-001. Tests confirm successful installation and functionality.