### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/kadragon/knue-ics-calendar/security/code-scanning/9](https://github.com/kadragon/knue-ics-calendar/security/code-scanning/9)

The correct fix is to add a `permissions` block specifying least-privilege access. In this case, since the actions in the workflow do not write to the repository or require elevated permissions, we can safely set `contents: read`. This can be added at the top level of the workflow (which applies to all jobs), or at the job level. Following CodeQL's suggestion, we should add:
```yaml
permissions:
  contents: read
```
This should be added immediately after the workflow `name` (after line 1), before the `on:` key at line 3. This approach is safe, explicit, and makes maintenance easier.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
