### PR TITLE
refactor: extract utils and add multi-year fetch with Gist sync

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,9 @@
+# Plan
+
+## Review Backlog
+
+### PR #87 — refactor: extract utils and add multi-year fetch with Gist sync (2026-04-06)
+
+- [ ] Gist 파일명을 환경변수로 설정 가능하게 하거나 기존 파일명 감지 (source: Codex) — src/gist.ts:22
+- [ ] 콘텐츠 변경 시에만 Gist 업데이트 (etag 비교) (source: Claude) — src/index.ts:161-172
+- [ ] gistId URL 삽입 시 hex 포맷 검증 추가 (source: Claude) — src/gist.ts:12

--- a/src/gist.ts
+++ b/src/gist.ts
@@ -9,31 +9,37 @@ export async function updateGist(
 	gistId: string,
 	icsContent: string,
 ): Promise<void> {
-	const url = `https://api.github.com/gists/${gistId}`;
-	const res = await fetch(url, {
-		method: "PATCH",
-		headers: {
-			authorization: `Bearer ${token}`,
-			accept: "application/vnd.github+json",
-			"user-agent": "KNUE-ICS-Calendar/1.0.0",
-		},
-		body: JSON.stringify({
-			files: {
-				"knue-calendar.ics": {
-					content: icsContent,
-				},
+	try {
+		const url = `https://api.github.com/gists/${gistId}`;
+		const res = await fetch(url, {
+			method: "PATCH",
+			headers: {
+				authorization: `Bearer ${token}`,
+				accept: "application/vnd.github+json",
+				"user-agent": "KNUE-ICS-Calendar/1.0.0",
 			},
-		}),
-	});
-
-	if (!res.ok) {
-		const body = await res.text();
-		log("error", "Gist update failed", {
-			status: res.status,
-			body: body.slice(0, 200),
+			body: JSON.stringify({
+				files: {
+					"knue-calendar.ics": {
+						content: icsContent,
+					},
+				},
+			}),
 		});
-		return;
-	}
 
-	log("info", "Gist updated successfully");
+		if (!res.ok) {
+			const body = await res.text();
+			log("error", "Gist update failed", {
+				status: res.status,
+				body: body.slice(0, 200),
+				gistId,
+			});
+			return;
+		}
+
+		log("info", "Gist updated successfully");
+	} catch (err: unknown) {
+		const message = err instanceof Error ? err.message : String(err);
+		log("error", "Gist update error", { error: message, gistId });
+	}
 }

--- a/src/gist.ts
+++ b/src/gist.ts
@@ -1,0 +1,39 @@
+import { log } from "./utils/logger";
+
+/**
+ * Update a GitHub Gist with ICS content.
+ * Non-fatal: logs errors but never throws.
+ */
+export async function updateGist(
+	token: string,
+	gistId: string,
+	icsContent: string,
+): Promise<void> {
+	const url = `https://api.github.com/gists/${gistId}`;
+	const res = await fetch(url, {
+		method: "PATCH",
+		headers: {
+			authorization: `Bearer ${token}`,
+			accept: "application/vnd.github+json",
+			"user-agent": "KNUE-ICS-Calendar/1.0.0",
+		},
+		body: JSON.stringify({
+			files: {
+				"knue-calendar.ics": {
+					content: icsContent,
+				},
+			},
+		}),
+	});
+
+	if (!res.ok) {
+		const body = await res.text();
+		log("error", "Gist update failed", {
+			status: res.status,
+			body: body.slice(0, 200),
+		});
+		return;
+	}
+
+	log("info", "Gist updated successfully");
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,11 @@
 import { CACHE_CONFIG, CACHE_KEY } from "./constants";
+import { updateGist } from "./gist";
 import { getEventsFromSite } from "./parser";
 import type { Env } from "./types";
+import { getAcademicYearsToFetch } from "./utils/academic-year";
 import { createCalendarWithEvents } from "./utils/calendar";
 import { generateEtag } from "./utils/etag";
+import { deduplicateEvents } from "./utils/events";
 import { log } from "./utils/logger";
 
 type IcsMetadata = {
@@ -67,8 +70,14 @@ const generateAndSaveIcs = async (
 	updatedAt: string;
 }> => {
 	log("info", "Generating ICS on-demand");
-	const currentYear = new Date().getFullYear();
-	const events = await getEventsFromSite(currentYear);
+	const [current, previous] = getAcademicYearsToFetch(new Date());
+	const [currentEvents, prevEvents] = await Promise.all([
+		getEventsFromSite(current),
+		getEventsFromSite(previous),
+	]);
+	const events = deduplicateEvents([...prevEvents, ...currentEvents]).sort(
+		(a, b) => a.start.getTime() - b.start.getTime(),
+	);
 
 	if (!events || events.length === 0) {
 		log("error", "No events parsed from site");
@@ -93,7 +102,7 @@ const generateAndSaveIcs = async (
 };
 
 export default {
-	async fetch(req: Request, env: Env) {
+	async fetch(req: Request, env: Env, ctx: ExecutionContext) {
 		try {
 			const url = new URL(req.url);
 			if (url.pathname.endsWith(".ics")) {
@@ -148,6 +157,19 @@ export default {
 						ics = result.ics;
 						etag = result.etag;
 						updatedAt = result.updatedAt;
+
+						// Push to Gist in background (non-blocking, non-fatal)
+						if (env.GITHUB_TOKEN && env.GIST_ID) {
+							ctx.waitUntil(
+								updateGist(env.GITHUB_TOKEN, env.GIST_ID, ics).catch(
+									(err: unknown) => {
+										const message =
+											err instanceof Error ? err.message : String(err);
+										log("error", "Gist update error", { error: message });
+									},
+								),
+							);
+						}
 					} catch (_genErr: unknown) {
 						// If generation fails and we have old ICS, serve it
 						if (kvIcs) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -160,15 +160,7 @@ export default {
 
 						// Push to Gist in background (non-blocking, non-fatal)
 						if (env.GITHUB_TOKEN && env.GIST_ID) {
-							ctx.waitUntil(
-								updateGist(env.GITHUB_TOKEN, env.GIST_ID, ics).catch(
-									(err: unknown) => {
-										const message =
-											err instanceof Error ? err.message : String(err);
-										log("error", "Gist update error", { error: message });
-									},
-								),
-							);
+							ctx.waitUntil(updateGist(env.GITHUB_TOKEN, env.GIST_ID, ics));
 						}
 					} catch (_genErr: unknown) {
 						// If generation fails and we have old ICS, serve it

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,4 +7,6 @@ export interface Event {
 
 export interface Env {
 	KNUE_CAL_KV: KVNamespace;
+	GITHUB_TOKEN?: string;
+	GIST_ID?: string;
 }

--- a/src/utils/academic-year.ts
+++ b/src/utils/academic-year.ts
@@ -1,0 +1,16 @@
+/**
+ * 학사년도: 3월~익년 2월. 3월 이상이면 해당 연도, 1~2월이면 전년도.
+ */
+export function getAcademicYear(date: Date): number {
+	const month = date.getMonth() + 1;
+	return month >= 3 ? date.getFullYear() : date.getFullYear() - 1;
+}
+
+/**
+ * 현재 학사년도와 이전 학사년도를 반환.
+ * 두 학사년도를 fetch하면 연도 경계의 이벤트 누락을 방지할 수 있음.
+ */
+export function getAcademicYearsToFetch(date: Date): [number, number] {
+	const current = getAcademicYear(date);
+	return [current, current - 1];
+}

--- a/src/utils/academic-year.ts
+++ b/src/utils/academic-year.ts
@@ -1,9 +1,13 @@
 /**
  * 학사년도: 3월~익년 2월. 3월 이상이면 해당 연도, 1~2월이면 전년도.
+ * CF Workers는 UTC 기준이므로 Asia/Seoul 타임존으로 변환하여 계산.
  */
 export function getAcademicYear(date: Date): number {
-	const month = date.getMonth() + 1;
-	return month >= 3 ? date.getFullYear() : date.getFullYear() - 1;
+	const koreaDate = new Date(
+		date.toLocaleString("en-US", { timeZone: "Asia/Seoul" }),
+	);
+	const month = koreaDate.getMonth() + 1;
+	return month >= 3 ? koreaDate.getFullYear() : koreaDate.getFullYear() - 1;
 }
 
 /**

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -1,0 +1,14 @@
+import type { Event } from "../types";
+
+/**
+ * title + start + end 기준으로 중복 이벤트를 제거.
+ */
+export function deduplicateEvents(events: Event[]): Event[] {
+	const seen = new Set<string>();
+	return events.filter((event) => {
+		const key = `${event.title}|${event.start.getTime()}|${event.end.getTime()}`;
+		if (seen.has(key)) return false;
+		seen.add(key);
+		return true;
+	});
+}

--- a/tasks.md
+++ b/tasks.md
@@ -1,0 +1,22 @@
+# Tasks
+
+## ICS 연도 경계 버그 수정
+> Goal: 이전 학사년도의 1~2월 이벤트가 누락되는 문제 해결
+> Design: .claude/plans/staged-coalescing-muffin.md
+> Done-when: 2026년 4월 시점에서 2026년 1~2월 이벤트가 ICS에 포함됨
+
+- [ ] `src/utils/academic-year.ts` — 학사년도 계산 함수 (`getAcademicYear`, `getAcademicYearsToFetch`)
+- [ ] `src/utils/events.ts` — 이벤트 중복 제거 함수 (`deduplicateEvents`)
+- [ ] `src/index.ts` — `generateAndSaveIcs`에서 두 학사년도 병렬 fetch + 병합 + 정렬
+- [ ] 테스트 작성 (`academic-year.test.ts`, `events.test.ts`, `index.test.ts` 업데이트)
+
+## GitHub Gist 서빙 옵션
+> Goal: ICS 파일을 Gist raw URL로도 구독 가능하게
+> Design: .claude/plans/staged-coalescing-muffin.md
+> Done-when: ICS 생성 시 Gist 자동 업데이트, raw URL로 캘린더 구독 가능
+
+- [ ] `src/gist.ts` — GitHub API PATCH로 Gist 업데이트
+- [ ] `src/types.ts` — `Env`에 `GITHUB_TOKEN?`, `GIST_ID?` 추가
+- [ ] `src/index.ts` — KV 저장 후 선택적 Gist push (`ctx.waitUntil`, non-fatal)
+- [ ] Cloudflare secret 설정 (`wrangler secret put GITHUB_TOKEN`)
+- [ ] 테스트 작성 (`gist.test.ts`)

--- a/tests/gist.test.ts
+++ b/tests/gist.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { updateGist } from "../src/gist";
+
+describe("updateGist", () => {
+	const originalFetch = globalThis.fetch;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	it("should call GitHub API with correct parameters", async () => {
+		const mockFetch = vi
+			.fn()
+			.mockResolvedValue(new Response("OK", { status: 200 }));
+		globalThis.fetch = mockFetch;
+
+		await updateGist("test-token", "gist-123", "ICS content");
+
+		expect(mockFetch).toHaveBeenCalledOnce();
+		const [url, options] = mockFetch.mock.calls[0];
+		expect(url).toBe("https://api.github.com/gists/gist-123");
+		expect(options.method).toBe("PATCH");
+		expect(options.headers.authorization).toBe("Bearer test-token");
+		expect(options.headers.accept).toBe("application/vnd.github+json");
+
+		const body = JSON.parse(options.body);
+		expect(body.files["knue-calendar.ics"].content).toBe("ICS content");
+	});
+
+	it("should log error on non-OK response without throwing", async () => {
+		const mockFetch = vi
+			.fn()
+			.mockResolvedValue(new Response("Not Found", { status: 404 }));
+		globalThis.fetch = mockFetch;
+
+		// Should not throw
+		await expect(
+			updateGist("test-token", "bad-id", "ICS content"),
+		).resolves.toBeUndefined();
+	});
+
+	it("should not catch fetch errors (caller handles)", async () => {
+		const mockFetch = vi.fn().mockRejectedValue(new Error("Network error"));
+		globalThis.fetch = mockFetch;
+
+		// updateGist does not catch fetch errors — they propagate to the caller
+		await expect(
+			updateGist("test-token", "gist-123", "ICS content"),
+		).rejects.toThrow("Network error");
+	});
+});

--- a/tests/gist.test.ts
+++ b/tests/gist.test.ts
@@ -43,13 +43,13 @@ describe("updateGist", () => {
 		).resolves.toBeUndefined();
 	});
 
-	it("should not catch fetch errors (caller handles)", async () => {
+	it("should catch fetch errors without throwing", async () => {
 		const mockFetch = vi.fn().mockRejectedValue(new Error("Network error"));
 		globalThis.fetch = mockFetch;
 
-		// updateGist does not catch fetch errors — they propagate to the caller
+		// updateGist catches all errors internally — never throws
 		await expect(
 			updateGist("test-token", "gist-123", "ICS content"),
-		).rejects.toThrow("Network error");
+		).resolves.toBeUndefined();
 	});
 });

--- a/tests/helpers/mocks.ts
+++ b/tests/helpers/mocks.ts
@@ -142,6 +142,16 @@ export function createMockRequest(
 	return new Request(url, { headers });
 }
 
+export function createMockExecutionContext(): ExecutionContext {
+	return {
+		waitUntil: (_promise: Promise<unknown>) => {},
+		passThroughOnException: () => {},
+		abort: () => {},
+		exports: {},
+		props: undefined,
+	} as unknown as ExecutionContext;
+}
+
 export function createMockResponse(
 	body: string,
 	status: number = 200,

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import worker from "../src/index";
 import type { Env } from "../src/types";
 import {
+	createMockExecutionContext,
 	createMockRequest,
 	installMockCaches,
 	MockKVNamespace,
@@ -23,14 +24,21 @@ vi.mock("../src/parser", () => ({
 	]),
 }));
 
+// Mock the academic-year module to return predictable values
+vi.mock("../src/utils/academic-year", () => ({
+	getAcademicYearsToFetch: vi.fn().mockReturnValue([2024, 2023]),
+}));
+
 describe("Main Worker Handler", () => {
 	let kvStore: MockKVNamespace;
 	let env: Env;
+	let ctx: ExecutionContext;
 	let cacheRestore: { restore(): void };
 
 	beforeEach(() => {
 		kvStore = new MockKVNamespace();
 		env = { KNUE_CAL_KV: kvStore as unknown as KVNamespace };
+		ctx = createMockExecutionContext();
 		cacheRestore = installMockCaches();
 		vi.clearAllMocks();
 	});
@@ -43,7 +51,7 @@ describe("Main Worker Handler", () => {
 		it("should generate ICS on-demand when not in KV", async () => {
 			const request = createMockRequest("https://example.com/calendar.ics");
 
-			const response = await worker.fetch(request, env);
+			const response = await worker.fetch(request, env, ctx);
 
 			expect(response.status).toBe(200);
 			expect(response.headers.get("content-type")).toBe(
@@ -52,6 +60,17 @@ describe("Main Worker Handler", () => {
 			const ics = await response.text();
 			expect(ics).toContain("BEGIN:VCALENDAR");
 			expect(ics).toContain("개강일");
+		});
+
+		it("should fetch two academic years and call getEventsFromSite twice", async () => {
+			const { getEventsFromSite } = await import("../src/parser.js");
+
+			const request = createMockRequest("https://example.com/calendar.ics");
+			await worker.fetch(request, env, ctx);
+
+			expect(getEventsFromSite).toHaveBeenCalledTimes(2);
+			expect(getEventsFromSite).toHaveBeenCalledWith(2024);
+			expect(getEventsFromSite).toHaveBeenCalledWith(2023);
 		});
 
 		it("should return ICS file when available", async () => {
@@ -64,7 +83,7 @@ describe("Main Worker Handler", () => {
 			await kvStore.put("latest", icsContent, { metadata });
 
 			const request = createMockRequest("https://example.com/calendar.ics");
-			const response = await worker.fetch(request, env);
+			const response = await worker.fetch(request, env, ctx);
 
 			expect(response.status).toBe(200);
 			expect(await response.text()).toBe(icsContent);
@@ -82,7 +101,7 @@ describe("Main Worker Handler", () => {
 			const firstRequest = createMockRequest(
 				"https://example.com/calendar.ics",
 			);
-			const firstResponse = await worker.fetch(firstRequest, env);
+			const firstResponse = await worker.fetch(firstRequest, env, ctx);
 			const etag = firstResponse.headers.get("etag");
 			expect(etag).toBeTruthy();
 
@@ -93,7 +112,7 @@ describe("Main Worker Handler", () => {
 					"if-none-match": etag ?? "",
 				},
 			);
-			const secondResponse = await worker.fetch(secondRequest, env);
+			const secondResponse = await worker.fetch(secondRequest, env, ctx);
 
 			expect(secondResponse.status).toBe(304);
 		});
@@ -106,7 +125,7 @@ describe("Main Worker Handler", () => {
 				"accept-encoding": "gzip, deflate",
 			});
 
-			const response = await worker.fetch(request, env);
+			const response = await worker.fetch(request, env, ctx);
 
 			expect(response.status).toBe(200);
 			expect(response.headers.get("content-encoding")).toBeNull();
@@ -118,7 +137,7 @@ describe("Main Worker Handler", () => {
 		it("should return 404 for non-ICS paths", async () => {
 			const request = createMockRequest("https://example.com/other-path");
 
-			const response = await worker.fetch(request, env);
+			const response = await worker.fetch(request, env, ctx);
 
 			expect(response.status).toBe(404);
 			expect(await response.text()).toBe("Not found");
@@ -137,7 +156,7 @@ describe("Main Worker Handler", () => {
 			} as Env;
 
 			const request = createMockRequest("https://example.com/calendar.ics");
-			const response = await worker.fetch(request, errorEnv);
+			const response = await worker.fetch(request, errorEnv, ctx);
 
 			expect(response.status).toBe(500);
 			expect(await response.text()).toBe("Internal server error");
@@ -156,7 +175,7 @@ describe("Main Worker Handler", () => {
 			} as Env;
 
 			const request = createMockRequest("https://example.com/calendar.ics");
-			const response = await worker.fetch(request, errorEnv);
+			const response = await worker.fetch(request, errorEnv, ctx);
 
 			expect(response.status).toBe(500);
 			expect(await response.text()).toBe("Internal server error");
@@ -175,7 +194,7 @@ describe("Main Worker Handler", () => {
 			await kvStore.put("latest", icsContent, { metadata });
 
 			const request = createMockRequest("https://example.com/calendar.ics");
-			const response = await worker.fetch(request, env);
+			const response = await worker.fetch(request, env, ctx);
 
 			expect(response.status).toBe(200);
 			expect(await response.text()).toBe(icsContent);
@@ -194,7 +213,7 @@ describe("Main Worker Handler", () => {
 			await kvStore.put("latest", oldIcs, { metadata });
 
 			const request = createMockRequest("https://example.com/calendar.ics");
-			const response = await worker.fetch(request, env);
+			const response = await worker.fetch(request, env, ctx);
 
 			expect(response.status).toBe(200);
 			const ics = await response.text();
@@ -220,7 +239,7 @@ describe("Main Worker Handler", () => {
 			);
 
 			const request = createMockRequest("https://example.com/calendar.ics");
-			const response = await worker.fetch(request, env);
+			const response = await worker.fetch(request, env, ctx);
 
 			// Should serve stale cache instead of failing
 			expect(response.status).toBe(200);
@@ -235,7 +254,7 @@ describe("Main Worker Handler", () => {
 			);
 
 			const request = createMockRequest("https://example.com/calendar.ics");
-			const response = await worker.fetch(request, env);
+			const response = await worker.fetch(request, env, ctx);
 
 			expect(response.status).toBe(503);
 			expect(await response.text()).toBe("Calendar not available yet");

--- a/tests/utils/academic-year.test.ts
+++ b/tests/utils/academic-year.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+	getAcademicYear,
+	getAcademicYearsToFetch,
+} from "../../src/utils/academic-year";
+
+describe("getAcademicYear", () => {
+	it("should return current year for March (start of academic year)", () => {
+		expect(getAcademicYear(new Date("2026-03-01"))).toBe(2026);
+	});
+
+	it("should return current year for December", () => {
+		expect(getAcademicYear(new Date("2026-12-15"))).toBe(2026);
+	});
+
+	it("should return previous year for January", () => {
+		expect(getAcademicYear(new Date("2026-01-15"))).toBe(2025);
+	});
+
+	it("should return previous year for February", () => {
+		expect(getAcademicYear(new Date("2026-02-28"))).toBe(2025);
+	});
+});
+
+describe("getAcademicYearsToFetch", () => {
+	it("should return [current, previous] academic years for April", () => {
+		expect(getAcademicYearsToFetch(new Date("2026-04-05"))).toEqual([
+			2026, 2025,
+		]);
+	});
+
+	it("should return [current, previous] academic years for January", () => {
+		expect(getAcademicYearsToFetch(new Date("2026-01-15"))).toEqual([
+			2025, 2024,
+		]);
+	});
+});

--- a/tests/utils/events.test.ts
+++ b/tests/utils/events.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import type { Event } from "../../src/types";
+import { deduplicateEvents } from "../../src/utils/events";
+
+describe("deduplicateEvents", () => {
+	it("should remove duplicate events with same title, start, and end", () => {
+		const events: Event[] = [
+			{
+				title: "개강일",
+				start: new Date("2026-03-01"),
+				end: new Date("2026-03-01"),
+			},
+			{
+				title: "개강일",
+				start: new Date("2026-03-01"),
+				end: new Date("2026-03-01"),
+			},
+		];
+
+		const result = deduplicateEvents(events);
+		expect(result).toHaveLength(1);
+		expect(result[0].title).toBe("개강일");
+	});
+
+	it("should keep events with different titles", () => {
+		const events: Event[] = [
+			{
+				title: "개강일",
+				start: new Date("2026-03-01"),
+				end: new Date("2026-03-01"),
+			},
+			{
+				title: "종강일",
+				start: new Date("2026-03-01"),
+				end: new Date("2026-03-01"),
+			},
+		];
+
+		const result = deduplicateEvents(events);
+		expect(result).toHaveLength(2);
+	});
+
+	it("should keep events with different dates but same title", () => {
+		const events: Event[] = [
+			{
+				title: "회의",
+				start: new Date("2026-03-01"),
+				end: new Date("2026-03-01"),
+			},
+			{
+				title: "회의",
+				start: new Date("2026-04-01"),
+				end: new Date("2026-04-01"),
+			},
+		];
+
+		const result = deduplicateEvents(events);
+		expect(result).toHaveLength(2);
+	});
+
+	it("should preserve order of first occurrence", () => {
+		const events: Event[] = [
+			{
+				title: "A",
+				start: new Date("2026-01-01"),
+				end: new Date("2026-01-01"),
+			},
+			{
+				title: "B",
+				start: new Date("2026-02-01"),
+				end: new Date("2026-02-01"),
+			},
+			{
+				title: "A",
+				start: new Date("2026-01-01"),
+				end: new Date("2026-01-01"),
+			},
+		];
+
+		const result = deduplicateEvents(events);
+		expect(result).toHaveLength(2);
+		expect(result[0].title).toBe("A");
+		expect(result[1].title).toBe("B");
+	});
+
+	it("should return empty array for empty input", () => {
+		expect(deduplicateEvents([])).toEqual([]);
+	});
+});

--- a/tests/worker-cache.spec.ts
+++ b/tests/worker-cache.spec.ts
@@ -3,6 +3,7 @@ import { CACHE_KEY } from "../src/constants";
 import worker from "../src/index";
 import type { Env } from "../src/types";
 import {
+	createMockExecutionContext,
 	createMockRequest,
 	installMockCaches,
 	MockKVNamespace,
@@ -18,14 +19,20 @@ vi.mock("../src/parser", () => ({
 	]),
 }));
 
+vi.mock("../src/utils/academic-year", () => ({
+	getAcademicYearsToFetch: vi.fn().mockReturnValue([2024, 2023]),
+}));
+
 describe("Worker Cache Integration", () => {
 	let kv: MockKVNamespace;
 	let env: Env;
+	let ctx: ExecutionContext;
 	let cacheRestore: { restore(): void };
 
 	beforeEach(() => {
 		kv = new MockKVNamespace();
 		env = { KNUE_CAL_KV: kv as unknown as KVNamespace };
+		ctx = createMockExecutionContext();
 
 		cacheRestore = installMockCaches();
 		vi.clearAllMocks();
@@ -49,7 +56,7 @@ describe("Worker Cache Integration", () => {
 		await caches.default.put(new Request(CACHE_KEY), cacheResponse);
 
 		const request = createMockRequest("https://example.com/events.ics");
-		const response = await worker.fetch(request, env);
+		const response = await worker.fetch(request, env, ctx);
 
 		expect(response.status).toBe(200);
 		expect(await response.text()).toBe(icsContent);
@@ -66,7 +73,7 @@ describe("Worker Cache Integration", () => {
 		});
 
 		const request = createMockRequest("https://example.com/events.ics");
-		const response = await worker.fetch(request, env);
+		const response = await worker.fetch(request, env, ctx);
 
 		expect(response.status).toBe(200);
 		expect(await response.text()).toBe(icsContent);
@@ -81,7 +88,7 @@ describe("Worker Cache Integration", () => {
 	it("warms cache after on-demand generation", async () => {
 		// Trigger on-demand ICS generation by requesting when cache is empty
 		const request = createMockRequest("https://example.com/events.ics");
-		const response = await worker.fetch(request, env);
+		const response = await worker.fetch(request, env, ctx);
 
 		expect(response.status).toBe(200);
 
@@ -96,7 +103,7 @@ describe("Worker Cache Integration", () => {
 		await kv.put("latest", icsContent);
 
 		const request = createMockRequest("https://example.com/events.ics");
-		const response = await worker.fetch(request, env);
+		const response = await worker.fetch(request, env, ctx);
 
 		expect(response.status).toBe(200);
 		// Should regenerate since metadata is missing


### PR DESCRIPTION
## Summary
- Extract `academic-year`, `events` (dedup), and `gist` modules from `index.ts` into dedicated files
- Fetch two academic years (current + previous) to prevent event loss at year boundaries
- Add background Gist sync via `ctx.waitUntil` for optional ICS publishing
- Add `GITHUB_TOKEN` and `GIST_ID` to `Env` type
- Add comprehensive tests for all new modules

## Test plan
- [x] All 76 existing + new tests pass
- [ ] Verify multi-year fetch captures boundary events correctly
- [ ] Verify Gist sync is non-blocking and non-fatal on failure
- [ ] Verify deduplication removes identical events from overlapping years

🤖 Generated with [Claude Code](https://claude.com/claude-code)