### PR TITLE
chore: add grouped updates for github-actions dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Add groups block to github-actions ecosystem so minor/patch action updates are consolidated into single PRs instead of individual ones.