### PR TITLE
feat: harden Gist sync — filename env-var, skip-on-no-change, gistId validation

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -4,6 +4,6 @@
 
 ### PR #87 — refactor: extract utils and add multi-year fetch with Gist sync (2026-04-06)
 
-- [ ] Gist 파일명을 환경변수로 설정 가능하게 하거나 기존 파일명 감지 (source: Codex) — src/gist.ts:22
-- [ ] 콘텐츠 변경 시에만 Gist 업데이트 (etag 비교) (source: Claude) — src/index.ts:161-172
-- [ ] gistId URL 삽입 시 hex 포맷 검증 추가 (source: Claude) — src/gist.ts:12
+- [x] Gist 파일명을 환경변수로 설정 가능하게 하거나 기존 파일명 감지 (source: Codex) — src/gist.ts:22
+- [x] 콘텐츠 변경 시에만 Gist 업데이트 (eventsHash 비교) (source: Claude) — src/index.ts
+- [x] gistId URL 삽입 시 hex 포맷 검증 추가 (source: Claude) — src/gist.ts:12

--- a/src/gist.ts
+++ b/src/gist.ts
@@ -1,5 +1,7 @@
 import { log } from "./utils/logger";
 
+const GIST_ID_RE = /^[0-9a-fA-F]{20,40}$/;
+
 /**
  * Update a GitHub Gist with ICS content.
  * Non-fatal: logs errors but never throws.
@@ -8,7 +10,13 @@ export async function updateGist(
 	token: string,
 	gistId: string,
 	icsContent: string,
+	filename = "knue-calendar.ics",
 ): Promise<void> {
+	if (!GIST_ID_RE.test(gistId)) {
+		log("error", "Invalid gistId format", { gistIdLength: gistId.length });
+		return;
+	}
+
 	try {
 		const url = `https://api.github.com/gists/${gistId}`;
 		const res = await fetch(url, {
@@ -20,7 +28,7 @@ export async function updateGist(
 			},
 			body: JSON.stringify({
 				files: {
-					"knue-calendar.ics": {
+					[filename]: {
 						content: icsContent,
 					},
 				},

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { log } from "./utils/logger";
 type IcsMetadata = {
 	updatedAt?: string;
 	etag?: string;
+	eventsHash?: string;
 };
 
 const cacheRequest = new Request(CACHE_KEY);
@@ -64,10 +65,12 @@ const extractKvData = async (
  */
 const generateAndSaveIcs = async (
 	env: Env,
+	previousEventsHash?: string,
 ): Promise<{
 	ics: string;
 	etag: string;
 	updatedAt: string;
+	changed: boolean;
 }> => {
 	log("info", "Generating ICS on-demand");
 	const [current, previous] = getAcademicYearsToFetch(new Date());
@@ -84,6 +87,12 @@ const generateAndSaveIcs = async (
 		throw new Error("No events found from site");
 	}
 
+	const eventsFingerprint = events
+		.map((e) => `${e.title}|${e.start.toISOString()}|${e.end.toISOString()}`)
+		.join("\n");
+	const eventsHash = await generateEtag(eventsFingerprint);
+	const changed = eventsHash !== previousEventsHash;
+
 	const calendar = createCalendarWithEvents(events);
 	const icsString = calendar.toString();
 	const updatedAt = new Date().toISOString();
@@ -94,11 +103,12 @@ const generateAndSaveIcs = async (
 		metadata: {
 			updatedAt,
 			etag,
+			eventsHash,
 		},
 	});
 
 	log("info", "ICS generated and saved to KV");
-	return { ics: icsString, etag, updatedAt };
+	return { ics: icsString, etag, updatedAt, changed };
 };
 
 export default {
@@ -153,14 +163,26 @@ export default {
 						log("info", "KV cache is empty, generating ICS");
 					}
 					try {
-						const result = await generateAndSaveIcs(env);
+						const result = await generateAndSaveIcs(
+							env,
+							kvMetadata?.eventsHash,
+						);
 						ics = result.ics;
 						etag = result.etag;
 						updatedAt = result.updatedAt;
 
-						// Push to Gist in background (non-blocking, non-fatal)
-						if (env.GITHUB_TOKEN && env.GIST_ID) {
-							ctx.waitUntil(updateGist(env.GITHUB_TOKEN, env.GIST_ID, ics));
+						// Push to Gist in background only when content changed (non-blocking, non-fatal)
+						if (result.changed && env.GITHUB_TOKEN && env.GIST_ID) {
+							ctx.waitUntil(
+								updateGist(
+									env.GITHUB_TOKEN,
+									env.GIST_ID,
+									ics,
+									env.GIST_FILENAME,
+								),
+							);
+						} else if (!result.changed && env.GITHUB_TOKEN && env.GIST_ID) {
+							log("info", "Gist update skipped — content unchanged");
 						}
 					} catch (_genErr: unknown) {
 						// If generation fails and we have old ICS, serve it

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,4 +9,5 @@ export interface Env {
 	KNUE_CAL_KV: KVNamespace;
 	GITHUB_TOKEN?: string;
 	GIST_ID?: string;
+	GIST_FILENAME?: string;
 }

--- a/tests/gist.test.ts
+++ b/tests/gist.test.ts
@@ -12,17 +12,19 @@ describe("updateGist", () => {
 		globalThis.fetch = originalFetch;
 	});
 
+	const VALID_GIST_ID = "a".repeat(32);
+
 	it("should call GitHub API with correct parameters", async () => {
 		const mockFetch = vi
 			.fn()
 			.mockResolvedValue(new Response("OK", { status: 200 }));
 		globalThis.fetch = mockFetch;
 
-		await updateGist("test-token", "gist-123", "ICS content");
+		await updateGist("test-token", VALID_GIST_ID, "ICS content");
 
 		expect(mockFetch).toHaveBeenCalledOnce();
 		const [url, options] = mockFetch.mock.calls[0];
-		expect(url).toBe("https://api.github.com/gists/gist-123");
+		expect(url).toBe(`https://api.github.com/gists/${VALID_GIST_ID}`);
 		expect(options.method).toBe("PATCH");
 		expect(options.headers.authorization).toBe("Bearer test-token");
 		expect(options.headers.accept).toBe("application/vnd.github+json");
@@ -31,15 +33,38 @@ describe("updateGist", () => {
 		expect(body.files["knue-calendar.ics"].content).toBe("ICS content");
 	});
 
+	it("should use custom filename when provided", async () => {
+		const mockFetch = vi
+			.fn()
+			.mockResolvedValue(new Response("OK", { status: 200 }));
+		globalThis.fetch = mockFetch;
+
+		await updateGist("test-token", VALID_GIST_ID, "ICS content", "my-cal.ics");
+
+		const [, options] = mockFetch.mock.calls[0];
+		const body = JSON.parse(options.body);
+		expect(body.files["my-cal.ics"].content).toBe("ICS content");
+		expect(body.files["knue-calendar.ics"]).toBeUndefined();
+	});
+
+	it("should reject invalid gistId and not call fetch", async () => {
+		const mockFetch = vi.fn();
+		globalThis.fetch = mockFetch;
+
+		await updateGist("test-token", "not-hex!", "ICS content");
+		await updateGist("test-token", "", "ICS content");
+
+		expect(mockFetch).not.toHaveBeenCalled();
+	});
+
 	it("should log error on non-OK response without throwing", async () => {
 		const mockFetch = vi
 			.fn()
 			.mockResolvedValue(new Response("Not Found", { status: 404 }));
 		globalThis.fetch = mockFetch;
 
-		// Should not throw
 		await expect(
-			updateGist("test-token", "bad-id", "ICS content"),
+			updateGist("test-token", VALID_GIST_ID, "ICS content"),
 		).resolves.toBeUndefined();
 	});
 
@@ -47,9 +72,8 @@ describe("updateGist", () => {
 		const mockFetch = vi.fn().mockRejectedValue(new Error("Network error"));
 		globalThis.fetch = mockFetch;
 
-		// updateGist catches all errors internally — never throws
 		await expect(
-			updateGist("test-token", "gist-123", "ICS content"),
+			updateGist("test-token", VALID_GIST_ID, "ICS content"),
 		).resolves.toBeUndefined();
 	});
 });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -24,6 +24,10 @@ vi.mock("../src/parser", () => ({
 	]),
 }));
 
+vi.mock("../src/gist", () => ({
+	updateGist: vi.fn().mockResolvedValue(undefined),
+}));
+
 // Mock the academic-year module to return predictable values
 vi.mock("../src/utils/academic-year", () => ({
 	getAcademicYearsToFetch: vi.fn().mockReturnValue([2024, 2023]),
@@ -258,6 +262,60 @@ describe("Main Worker Handler", () => {
 
 			expect(response.status).toBe(503);
 			expect(await response.text()).toBe("Calendar not available yet");
+		});
+	});
+
+	describe("Gist update behavior", () => {
+		const gistEnv = (): Env => ({
+			KNUE_CAL_KV: kvStore as unknown as KVNamespace,
+			GITHUB_TOKEN: "test-token",
+			GIST_ID: "a".repeat(32),
+		});
+
+		it("should call updateGist when content changes (no previous eventsHash)", async () => {
+			const { updateGist } = await import("../src/gist.js");
+			const request = createMockRequest("https://example.com/calendar.ics");
+
+			await worker.fetch(request, gistEnv(), ctx);
+
+			expect(vi.mocked(updateGist)).toHaveBeenCalledOnce();
+		});
+
+		it("should skip updateGist when eventsHash is unchanged", async () => {
+			const { updateGist } = await import("../src/gist.js");
+			const { generateEtag } = await import("../src/utils/etag.js");
+
+			// Pre-compute the eventsHash for the mocked fixed events
+			const fixedEvents = [
+				{
+					start: new Date("2024-03-01"),
+					end: new Date("2024-03-01"),
+					title: "개강일",
+				},
+				{
+					start: new Date("2024-06-01"),
+					end: new Date("2024-08-31"),
+					title: "여름방학",
+				},
+			].sort((a, b) => a.start.getTime() - b.start.getTime());
+			const fingerprint = fixedEvents
+				.map(
+					(e) => `${e.title}|${e.start.toISOString()}|${e.end.toISOString()}`,
+				)
+				.join("\n");
+			const eventsHash = await generateEtag(fingerprint);
+
+			// Store stale KV entry with the same eventsHash
+			const oldDate = new Date(Date.now() - 25 * 60 * 60 * 1000);
+			await kvStore.put("latest", "BEGIN:VCALENDAR\nEND:VCALENDAR", {
+				metadata: { updatedAt: oldDate.toISOString(), etag: "old", eventsHash },
+			});
+
+			vi.mocked(updateGist).mockClear();
+			const request = createMockRequest("https://example.com/calendar.ics");
+			await worker.fetch(request, gistEnv(), ctx);
+
+			expect(vi.mocked(updateGist)).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -10,6 +10,12 @@ mode = "smart"
 binding = "KNUE_CAL_KV"
 id = "1c76e5f4218341d495b39b38c9a7f0f8"
 
+# Optional: override the filename used inside the Gist (default: knue-calendar.ics)
+# [vars]
+# GIST_FILENAME = "knue-calendar.ics"
+#
+# Secrets (set via `wrangler secret put`): GITHUB_TOKEN, GIST_ID
+
 [observability]
 [observability.logs]
 enabled = true


### PR DESCRIPTION
## Summary

- Add `GIST_FILENAME` env var so existing Gist files are not shadowed by hardcoded `knue-calendar.ics`
- Skip GitHub PATCH when event list is unchanged; uses a stable `eventsHash` (title|start|end fingerprint) stored in KV metadata, bypassing `DTSTAMP` non-determinism in ical-generator output
- Validate `GIST_ID` is 20–40 hex chars before embedding in GitHub API URL

Closes all three items from the PR #87 review backlog in `plan.md`.

## Test plan

- [ ] `npm run typecheck && npm run lint && npm test` — all green
- [ ] `tests/gist.test.ts`: custom filename reflected in `body.files[filename]`; invalid gistId (`"not-hex!"`, `""`) does not call `fetch`
- [ ] `tests/index.test.ts`: same `eventsHash` in KV → `updateGist` mock not called; different hash → called

🤖 Generated with [Claude Code](https://claude.com/claude-code)