### PR TITLE
fix(ci): upgrade Node.js to v22 for Wrangler v4 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- Upgrade CI Node.js version from v20 to v22
- Required by wrangler@4.87.0+ which dropped Node.js v20 support

## Why
Dependabot PR #95 bumped wrangler to v4.87.0, which requires Node.js >=22.0.0.
CI was failing with: "Wrangler requires at least Node.js v22.0.0. You are using v20.20.2."

## Related
Fixes CI failure blocking dependabot PR #95

🤖 Generated with Claude Code